### PR TITLE
Add minimal LangChain MCP calendar integration

### DIFF
--- a/radicale-test/README.md
+++ b/radicale-test/README.md
@@ -1,0 +1,110 @@
+# LangChain MCP Calendar Integration
+
+Natural language calendar operations using LangChain + MCP + Radicale CalDAV server.
+
+## Quick Setup
+
+### 1. Install Dependencies
+```bash
+# Core packages
+pip install langchain langchain-openai python-dotenv caldav
+
+# Optional MCP packages (automatic fallback if missing)
+pip install langchain-mcp-adapters mcp
+```
+
+### 2. Install Radicale Server
+```bash
+sudo apt update
+sudo apt install radicale
+```
+
+### 3. Configure Radicale
+Edit `/etc/radicale/config`:
+```ini
+[server]
+hosts = localhost:5232
+
+[auth]
+# Authentication method
+# Value: none | htpasswd | remote_user | http_x_remote_user
+type = htpasswd
+# Htpasswd filename
+htpasswd_filename = /etc/radicale/users
+
+[storage]
+type = multifilesystem
+filesystem_folder = /var/lib/radicale/collections
+```
+
+Add a user:
+```bash
+sudo apt-get install apache2-utils
+sudo htpasswd -B /etc/radicale/users your_username
+```
+
+Start Radicale:
+```bash
+sudo systemctl enable radicale
+sudo systemctl start radicale
+```
+
+### 4. Set Environment Variables
+```bash
+# Required for OpenAI
+export OPENAI_API_KEY=your_api_key_here
+
+# Required for Radicale
+export RADICALE_URL=http://localhost:5232
+export RADICALE_USERNAME=your_username
+export RADICALE_PASSWORD=your_password
+```
+
+### 5. Run Example
+```bash
+python langchain_example_mcp.py
+```
+
+## Alternative: Local LLM Setup
+
+Instead of OpenAI, use local models:
+
+```bash
+# Install Ollama
+pip install langchain-ollama
+
+# Start Ollama and pull a model
+ollama serve
+ollama pull llama3.2
+```
+
+Set environment:
+```bash
+export USE_LOCAL_LLM=true
+export LOCAL_MODEL=llama3.2
+# Remove OPENAI_API_KEY
+```
+
+## Usage Examples
+
+- "What meetings do I have today?"
+- "Schedule a meeting with John tomorrow at 2pm"
+- "Show me all events next week"
+- "Create a dentist appointment next Friday at 10am"
+
+## Files
+
+- `langchain_example_mcp.py` - Main example script
+- `langchain_mcp_integration.py` - MCP integration layer
+- `mcp_radicale_server.py` - MCP server implementation
+- `radicale_calendar_manager.py` - Core calendar operations
+
+## Troubleshooting
+
+**Connection refused**: Check if Radicale is running with `systemctl status radicale`
+
+**No calendars found**: Create a calendar via web interface at `http://localhost:5232/`
+
+**Import errors**: Install missing dependencies or use manual fallback tools
+
+**OpenAI errors**: Use local LLM setup or check API key

--- a/radicale-test/langchain_example_mcp.py
+++ b/radicale-test/langchain_example_mcp.py
@@ -1,0 +1,370 @@
+"""
+Updated LangChain Example using MCP Integration
+
+This example demonstrates how to use the new MCP-based LangChain integration
+for calendar operations. It replaces the direct tool adapter approach with
+the standardized MCP integration.
+
+Features:
+- MCP-based tool loading
+- Async agent operations
+- Comprehensive error handling
+- Natural language calendar operations
+- Automatic cleanup
+
+Usage:
+    python langchain_example_mcp.py
+
+Dependencies:
+    pip install langchain langchain-openai langchain-mcp-adapters
+    # Set OPENAI_API_KEY in .env file
+"""
+
+import os
+import asyncio
+import logging
+from typing import List, Dict, Any
+
+# LangChain imports
+from langchain.agents import AgentExecutor, create_openai_functions_agent
+from langchain_openai import ChatOpenAI
+from langchain.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.schema import SystemMessage
+from langchain_core.tools import BaseTool
+
+# Environment configuration
+from dotenv import load_dotenv
+
+# Local imports
+from langchain_mcp_integration import CalendarMCPIntegration, get_calendar_tools
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("langchain-mcp-example")
+
+class MCPCalendarAgent:
+    """
+    LangChain agent with MCP-based calendar tools.
+    
+    This class provides a conversational interface for calendar operations
+    using LangChain agents powered by MCP tools from the Radicale calendar server.
+    """
+    
+    def __init__(self, model: str = "gpt-3.5-turbo", temperature: float = 0):
+        """
+        Initialize the MCP calendar agent.
+        
+        Args:
+            model: OpenAI model to use for the agent
+            temperature: Temperature setting for the LLM
+        """
+        load_dotenv()
+        
+        self.model = model
+        self.temperature = temperature
+        self.mcp_integration: CalendarMCPIntegration = None
+        self.agent_executor: AgentExecutor = None
+        self.tools: List[BaseTool] = []
+        
+        # Validate LLM configuration
+        use_local = os.getenv("USE_LOCAL_LLM", "false").lower() == "true"
+        if not use_local and not os.getenv("OPENAI_API_KEY"):
+            raise ValueError("OPENAI_API_KEY not found. Set USE_LOCAL_LLM=true to use local models.")
+    
+    async def initialize(self):
+        """
+        Initialize the MCP integration and create the LangChain agent.
+        """
+        logger.info("Initializing MCP calendar agent...")
+        
+        try:
+            # Initialize MCP integration and get tools
+            self.tools, self.mcp_integration = await get_calendar_tools()
+            
+            logger.info(f"Loaded {len(self.tools)} MCP tools: {[tool.name for tool in self.tools]}")
+            
+            # Create the system prompt
+            system_prompt = self._create_system_prompt()
+            
+            # Create the prompt template
+            prompt = ChatPromptTemplate.from_messages([
+                SystemMessage(content=system_prompt),
+                MessagesPlaceholder(variable_name="chat_history"),
+                ("human", "{input}"),
+                MessagesPlaceholder(variable_name="agent_scratchpad"),
+            ])
+            
+            # Initialize the LLM
+            use_local = os.getenv("USE_LOCAL_LLM", "false").lower() == "true"
+            if use_local:
+                try:
+                    from langchain_ollama import ChatOllama
+                    local_model = os.getenv("LOCAL_MODEL", "llama3.2")
+                    llm = ChatOllama(
+                        model=local_model,
+                        temperature=self.temperature
+                    )
+                except ImportError:
+                    raise ImportError("Install langchain-ollama for local LLM support: pip install langchain-ollama")
+            else:
+                llm = ChatOpenAI(
+                    model=self.model,
+                    temperature=self.temperature,
+                    max_tokens=4000,
+                    api_key=os.getenv("OPENAI_API_KEY")
+                )
+            
+            # Create the agent
+            agent = create_openai_functions_agent(
+                llm=llm,
+                prompt=prompt,
+                tools=self.tools
+            )
+            
+            # Create the agent executor
+            self.agent_executor = AgentExecutor(
+                agent=agent,
+                tools=self.tools,
+                verbose=True,
+                max_iterations=10,
+                early_stopping_method="generate"
+            )
+            
+            logger.info("MCP calendar agent initialized successfully")
+            
+        except Exception as e:
+            logger.error(f"Failed to initialize MCP calendar agent: {e}")
+            raise
+    
+    def _create_system_prompt(self) -> str:
+        """
+        Create a comprehensive system prompt for the calendar agent.
+        
+        Returns:
+            System prompt string
+        """
+        tool_descriptions = "\n".join([
+            f"- {tool.name}: {tool.description}" 
+            for tool in self.tools
+        ])
+        
+        return f"""You are a helpful and efficient calendar assistant powered by MCP (Model Context Protocol) tools.
+
+You can help users manage their calendar events using the following tools:
+{tool_descriptions}
+
+Guidelines for calendar operations:
+1. Always confirm details before creating or modifying events
+2. Use clear, natural language in your responses
+3. When dates/times are ambiguous, ask for clarification
+4. Provide helpful summaries after completing operations
+5. Handle errors gracefully and suggest alternatives
+
+Date/Time Format Guidelines:
+- Accept natural language dates (e.g., "tomorrow", "next Friday", "June 1st")
+- Convert them to ISO format (YYYY-MM-DDTHH:MM:SS) for tool calls
+- Default to 1-hour duration if end time not specified
+- Assume current timezone unless specified
+
+Calendar Selection:
+- If no calendar is specified, list available calendars first
+- Ask user to choose if multiple calendars are available
+- Remember user preferences within the conversation
+
+Error Handling:
+- If a tool operation fails, explain what went wrong
+- Suggest corrections or alternatives
+- Never expose technical error details to users
+
+Example Interactions:
+- "What meetings do I have tomorrow?" → Get events for tomorrow
+- "Schedule a meeting with John at 2pm" → Create event (ask for date if missing)
+- "Cancel my 3pm meeting" → Find and delete the event
+- "Move my morning meeting to afternoon" → Update event time
+
+Always be helpful, accurate, and efficient in your calendar management assistance."""
+    
+    async def run_operation(self, operation: str, chat_history: List[Dict[str, str]] = None) -> str:
+        """
+        Run a calendar operation using the MCP-based agent.
+        
+        Args:
+            operation: Natural language description of the calendar operation
+            chat_history: Previous conversation history
+            
+        Returns:
+            Agent response as a string
+        """
+        if not self.agent_executor:
+            await self.initialize()
+        
+        if chat_history is None:
+            chat_history = []
+        
+        try:
+            logger.info(f"Processing operation: {operation}")
+            
+            result = await self.agent_executor.ainvoke({
+                "input": operation,
+                "chat_history": chat_history
+            })
+            
+            response = result["output"]
+            logger.info(f"Operation completed successfully")
+            return response
+            
+        except Exception as e:
+            error_msg = f"Error performing calendar operation: {str(e)}"
+            logger.error(error_msg)
+            return error_msg
+    
+    async def run_interactive_session(self):
+        """
+        Run an interactive chat session with the calendar agent.
+        """
+        if not self.agent_executor:
+            await self.initialize()
+        
+        print("\n🗓️  Welcome to the MCP Calendar Assistant!")
+        print("Type your calendar requests in natural language.")
+        print("Examples: 'What meetings do I have today?', 'Schedule a meeting with John tomorrow at 2pm'")
+        print("Type 'quit', 'exit', or 'bye' to end the session.\n")
+        
+        chat_history = []
+        
+        while True:
+            try:
+                # Get user input
+                user_input = input("You: ").strip()
+                
+                # Check for exit commands
+                if user_input.lower() in ['quit', 'exit', 'bye', 'q']:
+                    print("👋 Goodbye! Have a great day!")
+                    break
+                
+                if not user_input:
+                    continue
+                
+                # Process the request
+                print("🤔 Processing your request...")
+                response = await self.run_operation(user_input, chat_history)
+                
+                # Display response
+                print(f"Assistant: {response}\n")
+                
+                # Update chat history
+                chat_history.append({"role": "human", "content": user_input})
+                chat_history.append({"role": "assistant", "content": response})
+                
+                # Keep chat history manageable
+                if len(chat_history) > 10:
+                    chat_history = chat_history[-10:]
+                
+            except KeyboardInterrupt:
+                print("\n👋 Session interrupted. Goodbye!")
+                break
+            except Exception as e:
+                print(f"❌ Error: {e}")
+                print("Please try again or type 'quit' to exit.\n")
+    
+    async def cleanup(self):
+        """Clean up MCP integration resources."""
+        if self.mcp_integration:
+            await self.mcp_integration.cleanup()
+            logger.info("MCP integration cleaned up")
+    
+    def get_integration_info(self) -> Dict[str, Any]:
+        """Get information about the MCP integration."""
+        if self.mcp_integration:
+            return self.mcp_integration.get_integration_info()
+        return {"status": "not_initialized"}
+
+# Predefined example operations
+EXAMPLE_OPERATIONS = [
+    "What calendars do I have access to?",
+    "List my events for today",
+    "Add a meeting with John tomorrow at 2pm for 1 hour in my work calendar",
+    "Show me all events in my calendar for the next 7 days",
+    "Create a dentist appointment next Friday at 10am"
+]
+
+async def run_examples():
+    """Run predefined example operations."""
+    print("🚀 Running MCP Calendar Agent Examples\n")
+    
+    agent = MCPCalendarAgent()
+    
+    try:
+        await agent.initialize()
+        
+        # Display integration info
+        info = agent.get_integration_info()
+        print(f"📋 Integration Info:")
+        print(f"   Method: {info.get('integration_method', 'unknown')}")
+        print(f"   Tools: {info.get('tool_count', 0)} loaded")
+        print(f"   Tool Names: {', '.join(info.get('tool_names', []))}\n")
+        
+        # Run example operations
+        for i, operation in enumerate(EXAMPLE_OPERATIONS, 1):
+            print(f"📝 Example {i}: {operation}")
+            print("🤔 Processing...")
+            
+            try:
+                result = await agent.run_operation(operation)
+                print(f"✅ Result: {result}\n")
+                
+                # Add a small delay between operations
+                await asyncio.sleep(1)
+                
+            except Exception as e:
+                print(f"❌ Error: {e}\n")
+        
+        print("✨ All examples completed!")
+        
+    except Exception as e:
+        print(f"❌ Failed to run examples: {e}")
+    finally:
+        await agent.cleanup()
+
+async def main():
+    """Main entry point with user choice of mode."""
+    print("🗓️  MCP Calendar Agent")
+    print("====================")
+    print("Choose a mode:")
+    print("1. Run interactive session")
+    print("2. Run predefined examples")
+    print("3. Quick test")
+    
+    try:
+        choice = input("\nEnter your choice (1, 2, or 3): ").strip()
+        
+        if choice == "1":
+            agent = MCPCalendarAgent()
+            try:
+                await agent.run_interactive_session()
+            finally:
+                await agent.cleanup()
+                
+        elif choice == "2":
+            await run_examples()
+            
+        elif choice == "3":
+            print("\n🧪 Running quick test...")
+            agent = MCPCalendarAgent()
+            try:
+                await agent.initialize()
+                result = await agent.run_operation("List my available calendars")
+                print(f"✅ Quick test result: {result}")
+            finally:
+                await agent.cleanup()
+                
+        else:
+            print("❌ Invalid choice. Please run the script again.")
+            
+    except KeyboardInterrupt:
+        print("\n👋 Goodbye!")
+    except Exception as e:
+        print(f"❌ Error: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/radicale-test/langchain_mcp_integration.py
+++ b/radicale-test/langchain_mcp_integration.py
@@ -1,0 +1,587 @@
+"""
+LangChain MCP Integration for Radicale Calendar
+
+This module provides integration between LangChain and MCP (Model Context Protocol)
+for calendar operations. It replaces the direct tool adapter approach with a 
+standardized MCP-based integration using LangChain's official MCP adapters.
+
+Features:
+- Uses LangChain MCP adapters for tool conversion
+- Supports multiple MCP transport methods (stdio, HTTP)
+- Automatic tool discovery and schema validation
+- Async operation support
+- Comprehensive error handling
+- Configuration-based MCP server management
+
+Usage:
+    # Basic usage with default configuration
+    integration = CalendarMCPIntegration()
+    tools = await integration.initialize()
+    
+    # Use with LangChain agent
+    agent = create_openai_functions_agent(llm, prompt, tools)
+    
+Dependencies:
+    pip install langchain-mcp-adapters mcp
+    # OR alternative:
+    pip install langchain-mcp-tools
+"""
+
+import os
+import json
+import asyncio
+import logging
+from typing import List, Dict, Any, Optional, Callable
+from pathlib import Path
+
+# LangChain imports
+from langchain.tools import Tool
+from langchain_core.tools import BaseTool
+
+# Environment configuration
+from dotenv import load_dotenv
+
+# Configure logging
+logger = logging.getLogger("langchain-mcp-integration")
+
+class MCPIntegrationError(Exception):
+    """Custom exception for MCP integration operations"""
+    pass
+
+class CalendarMCPIntegration:
+    """
+    LangChain MCP Integration for Radicale Calendar Operations.
+    
+    This class manages the connection between LangChain and MCP servers,
+    providing automatic tool discovery and conversion from MCP tools to
+    LangChain-compatible tools.
+    """
+    
+    def __init__(self, mcp_server_config: Optional[Dict[str, Any]] = None):
+        """
+        Initialize the MCP integration with server configuration.
+        
+        Args:
+            mcp_server_config: Dictionary containing MCP server configuration.
+                              If None, uses default configuration.
+        """
+        load_dotenv()
+        
+        self.mcp_server_config = mcp_server_config or self._get_default_config()
+        self.tools: List[BaseTool] = []
+        self.cleanup_fn: Optional[Callable] = None
+        self._mcp_client = None
+        self._integration_method = None
+        
+    def _get_default_config(self) -> Dict[str, Any]:
+        """
+        Get default MCP server configuration.
+        
+        Returns:
+            Dictionary containing default server configuration
+        """
+        # Get the directory where this script is located
+        script_dir = Path(__file__).parent
+        server_script = script_dir / "mcp_radicale_server.py"
+        
+        return {
+            "radicale-calendar": {
+                "command": "python",
+                "args": [str(server_script)],
+                "transport": "stdio",
+                "env": {
+                    "RADICALE_URL": os.getenv("RADICALE_URL", "http://localhost:5232"),
+                    "RADICALE_USERNAME": os.getenv("RADICALE_USERNAME", ""),
+                    "RADICALE_PASSWORD": os.getenv("RADICALE_PASSWORD", "")
+                }
+            }
+        }
+    
+    async def initialize(self) -> List[BaseTool]:
+        """
+        Initialize MCP connection and load calendar tools.
+        
+        Returns:
+            List of LangChain-compatible tools converted from MCP server
+            
+        Raises:
+            MCPIntegrationError: If initialization fails
+        """
+        logger.info("Initializing LangChain MCP integration for calendar operations")
+        
+        try:
+            # Try primary method: langchain-mcp-tools
+            tools = await self._initialize_with_mcp_tools()
+            if tools:
+                self._integration_method = "langchain-mcp-tools"
+                self.tools = tools
+                logger.info(f"Successfully initialized with langchain-mcp-tools: {len(tools)} tools loaded")
+                return tools
+                
+        except ImportError as e:
+            logger.warning(f"langchain-mcp-tools not available: {e}")
+        except Exception as e:
+            logger.warning(f"Failed to initialize with langchain-mcp-tools: {e}")
+        
+        try:
+            # Fallback method: langchain-mcp-adapters
+            tools = await self._initialize_with_adapters()
+            if tools:
+                self._integration_method = "langchain-mcp-adapters"
+                self.tools = tools
+                logger.info(f"Successfully initialized with langchain-mcp-adapters: {len(tools)} tools loaded")
+                return tools
+                
+        except ImportError as e:
+            logger.error(f"langchain-mcp-adapters not available: {e}")
+        except Exception as e:
+            logger.error(f"Failed to initialize with langchain-mcp-adapters: {e}")
+        
+        # If both methods fail, try manual tool creation
+        try:
+            tools = await self._initialize_manual_tools()
+            self._integration_method = "manual"
+            self.tools = tools
+            logger.info(f"Successfully initialized with manual tools: {len(tools)} tools loaded")
+            return tools
+            
+        except Exception as e:
+            logger.error(f"Failed to initialize with manual tools: {e}")
+            raise MCPIntegrationError(f"All MCP integration methods failed: {e}")
+    
+    async def _initialize_with_mcp_tools(self) -> List[BaseTool]:
+        """
+        Initialize using langchain-mcp-tools package.
+        
+        Returns:
+            List of converted LangChain tools
+        """
+        try:
+            from langchain_mcp_tools import convert_mcp_to_langchain_tools
+            
+            logger.info("Using langchain-mcp-tools for MCP integration")
+            
+            # Initialize MCP servers and get tools
+            tools, cleanup_fn = await convert_mcp_to_langchain_tools(
+                self.mcp_server_config
+            )
+            
+            self.cleanup_fn = cleanup_fn
+            
+            # Validate tools
+            if not tools:
+                raise MCPIntegrationError("No tools returned from MCP server")
+            
+            logger.info(f"Loaded {len(tools)} tools from MCP server using langchain-mcp-tools")
+            return tools
+            
+        except ImportError:
+            raise ImportError("langchain-mcp-tools package not installed")
+    
+    async def _initialize_with_adapters(self) -> List[BaseTool]:
+        """
+        Initialize using langchain-mcp-adapters package.
+        
+        Returns:
+            List of converted LangChain tools
+        """
+        try:
+            from langchain_mcp_adapters.client import load_mcp_tools
+            
+            logger.info("Using langchain-mcp-adapters for MCP integration")
+            
+            # For stdio transport
+            server_config = self.mcp_server_config.get("radicale-calendar", {})
+            if server_config.get("transport") == "stdio":
+                # Start the MCP server as a subprocess
+                import subprocess
+                
+                cmd = [server_config["command"]] + server_config["args"]
+                env = os.environ.copy()
+                env.update(server_config.get("env", {}))
+                
+                # Start MCP server process
+                self._mcp_process = subprocess.Popen(
+                    cmd,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    env=env,
+                    text=True
+                )
+                
+                # Load tools using stdio connection
+                from langchain_mcp_adapters.client import stdio_client
+                
+                # Create stdio connection and load tools
+                async with stdio_client(self._mcp_process.stdin, self._mcp_process.stdout) as session:
+                    tools = await load_mcp_tools(session)
+                    
+            else:
+                # For HTTP transport, connect to running server
+                from langchain_mcp_adapters.client import sse_client
+                server_url = f"http://localhost:8765/sse"
+                
+                async with sse_client(server_url) as session:
+                    tools = await load_mcp_tools(session)
+            
+            if not tools:
+                raise MCPIntegrationError("No tools returned from MCP server")
+            
+            logger.info(f"Loaded {len(tools)} tools from MCP server using langchain-mcp-adapters")
+            return tools
+            
+        except ImportError:
+            raise ImportError("langchain-mcp-adapters package not installed")
+    
+    async def _initialize_manual_tools(self) -> List[BaseTool]:
+        """
+        Fallback: Create tools manually by communicating with MCP server.
+        
+        Returns:
+            List of manually created LangChain tools
+        """
+        logger.info("Creating manual MCP tools as fallback")
+        
+        # Import the server class to get tool definitions
+        from mcp_radicale_server import MCPRadicaleServer
+        
+        # Create server instance to get tool information
+        server = MCPRadicaleServer()
+        
+        # Manually create LangChain tools that call the MCP server
+        tools = []
+        
+        def list_calendars_sync(input_str: str = "") -> str:
+            """List all available calendars"""
+            try:
+                if not server.calendar_manager.calendars:
+                    server.calendar_manager.connect()
+                calendar_names = [cal.name for cal in server.calendar_manager.calendars]
+                return json.dumps({
+                    "status": "success", 
+                    "calendars": calendar_names,
+                    "count": len(calendar_names)
+                })
+            except Exception as e:
+                return json.dumps({"status": "error", "message": str(e)})
+        
+        tools.append(Tool(
+            name="list_calendars",
+            func=list_calendars_sync,
+            description="List all available calendars in the Radicale server"
+        ))
+        
+        def parse_natural_date(date_str: str):
+            """Parse natural language dates into datetime objects"""
+            from datetime import datetime, timedelta
+            import re
+            
+            if not date_str:
+                return None
+                
+            date_str = date_str.strip().lower()
+            now = datetime.now()
+            
+            # Handle specific natural language patterns
+            if date_str == 'today':
+                return now.replace(hour=0, minute=0, second=0, microsecond=0)
+            elif date_str == 'tomorrow':
+                return (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+            elif date_str == 'yesterday':
+                return (now - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+            elif 'next friday' in date_str or 'friday' in date_str:
+                # Find next Friday
+                days_ahead = 4 - now.weekday()  # Friday is 4
+                if days_ahead <= 0:  # Today is Friday or past Friday
+                    days_ahead += 7
+                return (now + timedelta(days=days_ahead)).replace(hour=0, minute=0, second=0, microsecond=0)
+            elif 'next week' in date_str:
+                return (now + timedelta(weeks=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+            elif '+7 days' in date_str or 'next 7 days' in date_str:
+                return (now + timedelta(days=7)).replace(hour=0, minute=0, second=0, microsecond=0)
+            
+            # Try to parse as ISO format
+            try:
+                return datetime.fromisoformat(date_str.replace('Z', '+00:00'))
+            except ValueError:
+                pass
+            
+            # Try to parse as simple date format YYYY-MM-DD
+            try:
+                return datetime.strptime(date_str, '%Y-%m-%d')
+            except ValueError:
+                pass
+                
+            # If all else fails, raise error
+            raise ValueError(f"Could not parse date: {date_str}")
+        
+        def get_events_sync(input_str: str) -> str:
+            """Get events from calendar with parameter parsing"""
+            try:
+                from datetime import datetime
+                import re
+                
+                # Parse input parameters from string - handle comma-separated values
+                calendar_match = re.search(r'calendar[_\s]*name[:\s]*["\']?([^"\',:]+)["\']?', input_str, re.IGNORECASE)
+                start_match = re.search(r'start[_\s]*date[:\s]*["\']?([^"\',:]+)["\']?', input_str, re.IGNORECASE)
+                end_match = re.search(r'end[_\s]*date[:\s]*["\']?([^"\',:]+)["\']?', input_str, re.IGNORECASE)
+                
+                calendar_name = calendar_match.group(1).strip() if calendar_match else None
+                start_date = start_match.group(1).strip() if start_match else None
+                end_date = end_match.group(1).strip() if end_match else None
+                
+                # If no explicit parameters found, treat whole string as start_date
+                if not calendar_name and not start_date and not end_date:
+                    start_date = input_str.strip()
+                
+                start_dt = None
+                end_dt = None
+                
+                # Use natural date parsing
+                if start_date:
+                    start_dt = parse_natural_date(start_date)
+                if end_date:
+                    end_dt = parse_natural_date(end_date)
+                
+                # If no calendar specified, use first available
+                if not calendar_name and server.calendar_manager.calendars:
+                    calendar_name = server.calendar_manager.calendars[0].name
+                
+                events = server.calendar_manager.get_events(calendar_name, start_dt, end_dt)
+                
+                # If looking for events "after" a specific time, filter them
+                if "after" in input_str.lower() and start_dt:
+                    filtered_events = []
+                    for event in events:
+                        try:
+                            event_start = datetime.fromisoformat(event['start'].replace('Z', '+00:00'))
+                            if event_start >= start_dt:
+                                filtered_events.append(event)
+                        except:
+                            filtered_events.append(event)  # Include if can't parse
+                    events = filtered_events
+                
+                used_calendar = calendar_name or "Default Calendar"
+                
+                return json.dumps({
+                    "status": "success",
+                    "calendar": used_calendar,
+                    "events": events,
+                    "count": len(events)
+                })
+            except Exception as e:
+                return json.dumps({"status": "error", "message": str(e)})
+        
+        tools.append(Tool(
+            name="get_events",
+            func=get_events_sync,
+            description="Get events from a calendar within a date range. Provide parameters as text like 'calendar_name: Work, start_date: 2023-06-01'"
+        ))
+        
+        def parse_natural_datetime(datetime_str: str) -> str:
+            """Parse natural language datetime into ISO format"""
+            from datetime import datetime, timedelta
+            import re
+            
+            if not datetime_str:
+                return None
+                
+            datetime_str = datetime_str.strip().lower()
+            now = datetime.now()
+            
+            # Handle relative times like "tomorrow at 2pm", "next Friday at 10am"
+            time_match = re.search(r'at (\d{1,2})(?::(\d{2}))?\s*(am|pm)?', datetime_str)
+            hour = 0
+            minute = 0
+            
+            if time_match:
+                hour = int(time_match.group(1))
+                minute = int(time_match.group(2) or 0)
+                ampm = time_match.group(3)
+                
+                if ampm == 'pm' and hour != 12:
+                    hour += 12
+                elif ampm == 'am' and hour == 12:
+                    hour = 0
+            
+            # Get the base date
+            if 'today' in datetime_str:
+                base_date = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+            elif 'tomorrow' in datetime_str:
+                base_date = (now + timedelta(days=1)).replace(hour=hour, minute=minute, second=0, microsecond=0)
+            elif 'next friday' in datetime_str or 'friday' in datetime_str:
+                days_ahead = 4 - now.weekday()  # Friday is 4
+                if days_ahead <= 0:
+                    days_ahead += 7
+                base_date = (now + timedelta(days=days_ahead)).replace(hour=hour, minute=minute, second=0, microsecond=0)
+            else:
+                # Try to parse as ISO format first
+                try:
+                    return datetime.fromisoformat(datetime_str.replace('Z', '+00:00')).isoformat()
+                except ValueError:
+                    # Default to parsing as date only
+                    base_date = parse_natural_date(datetime_str)
+                    if base_date and (hour or minute):
+                        base_date = base_date.replace(hour=hour, minute=minute)
+                    elif not base_date:
+                        base_date = now.replace(hour=hour or 0, minute=minute or 0, second=0, microsecond=0)
+            
+            return base_date.isoformat()
+
+        def create_event_structured(calendar_name: str, summary: str, start: str, duration: int = 60) -> str:
+            """Create a new event with structured parameters"""
+            try:
+                # Parse natural language datetime
+                start_iso = parse_natural_datetime(start)
+                
+                # Calculate end time from duration (in minutes)
+                from datetime import datetime, timedelta
+                start_dt = datetime.fromisoformat(start_iso)
+                end_dt = start_dt + timedelta(minutes=duration)
+                
+                # If no calendar name provided, use first available
+                if not calendar_name and server.calendar_manager.calendars:
+                    calendar_name = server.calendar_manager.calendars[0].name
+                
+                # Create the event
+                event_data = {
+                    "summary": summary,
+                    "start": start_iso,
+                    "end": end_dt.isoformat()
+                }
+                
+                event_id = server.calendar_manager.add_event(calendar_name, event_data)
+                
+                return json.dumps({
+                    "status": "success",
+                    "message": f"Event '{summary}' created successfully",
+                    "event_id": event_id,
+                    "calendar": calendar_name,
+                    "start": start_iso,
+                    "duration": duration
+                })
+            except Exception as e:
+                return json.dumps({"status": "error", "message": str(e)})
+        
+        from langchain_core.tools import StructuredTool
+        from pydantic import BaseModel, Field
+        
+        class CreateEventInput(BaseModel):
+            calendar_name: str = Field(description="Name of the calendar to add event to")
+            summary: str = Field(description="Event title/summary")
+            start: str = Field(description="Start time - can be natural language like 'tomorrow at 2pm' or ISO format")
+            duration: int = Field(default=60, description="Duration in minutes (default 60)")
+        
+        tools.append(StructuredTool(
+            name="create_event",
+            func=create_event_structured,
+            description="Create a new calendar event with natural language date/time support",
+            args_schema=CreateEventInput
+        ))
+        
+        logger.info(f"Created {len(tools)} manual MCP tools")
+        return tools
+    
+    async def cleanup(self):
+        """
+        Clean up MCP connections and resources.
+        """
+        logger.info("Cleaning up MCP integration resources")
+        
+        try:
+            if self.cleanup_fn:
+                await self.cleanup_fn()
+                logger.info("MCP cleanup function called successfully")
+                
+            if hasattr(self, '_mcp_process') and self._mcp_process:
+                self._mcp_process.terminate()
+                self._mcp_process.wait()
+                logger.info("MCP server process terminated")
+                
+        except Exception as e:
+            logger.warning(f"Error during cleanup: {e}")
+    
+    def get_tool_names(self) -> List[str]:
+        """
+        Get names of all loaded tools.
+        
+        Returns:
+            List of tool names
+        """
+        return [tool.name for tool in self.tools]
+    
+    def get_tool_descriptions(self) -> Dict[str, str]:
+        """
+        Get descriptions of all loaded tools.
+        
+        Returns:
+            Dictionary mapping tool names to descriptions
+        """
+        return {tool.name: tool.description for tool in self.tools}
+    
+    def get_integration_info(self) -> Dict[str, Any]:
+        """
+        Get information about the current integration setup.
+        
+        Returns:
+            Dictionary containing integration details
+        """
+        return {
+            "integration_method": self._integration_method,
+            "server_config": self.mcp_server_config,
+            "tool_count": len(self.tools),
+            "tool_names": self.get_tool_names()
+        }
+
+# Convenience function for easy usage
+async def get_calendar_tools(config: Optional[Dict[str, Any]] = None) -> tuple[List[BaseTool], CalendarMCPIntegration]:
+    """
+    Convenience function to quickly get calendar tools and integration instance.
+    
+    Args:
+        config: Optional MCP server configuration
+        
+    Returns:
+        Tuple of (tools_list, integration_instance)
+        
+    Example:
+        tools, integration = await get_calendar_tools()
+        
+        # Use tools with LangChain
+        agent = create_openai_functions_agent(llm, prompt, tools)
+        
+        # Clean up when done
+        await integration.cleanup()
+    """
+    integration = CalendarMCPIntegration(config)
+    tools = await integration.initialize()
+    return tools, integration
+
+# Example usage
+if __name__ == "__main__":
+    async def main():
+        """Example usage of the MCP integration"""
+        integration = CalendarMCPIntegration()
+        
+        try:
+            # Initialize and get tools
+            tools = await integration.initialize()
+            
+            print(f"Loaded {len(tools)} calendar tools:")
+            for tool in tools:
+                print(f"  - {tool.name}: {tool.description}")
+            
+            # Test a tool
+            if tools:
+                first_tool = tools[0]
+                print(f"\nTesting tool: {first_tool.name}")
+                result = first_tool.run("")
+                print(f"Result: {result}")
+            
+        except Exception as e:
+            print(f"Error: {e}")
+        finally:
+            await integration.cleanup()
+    
+    asyncio.run(main())

--- a/radicale-test/mcp_radicale_server.py
+++ b/radicale-test/mcp_radicale_server.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""
+Enhanced MCP-compliant Radicale Calendar Server
+
+This module provides a fully MCP-compliant server for Radicale calendar operations
+using the FastMCP framework. It replaces the previous WebSocket-based bridge with
+a standardized MCP implementation that can be used with LangChain MCP adapters.
+
+Features:
+- Full MCP protocol compliance
+- Async operation support
+- Comprehensive error handling
+- Tool discovery and schema validation
+- Multiple transport options (stdio, HTTP)
+- Environment-based configuration
+
+Usage:
+    # Run with stdio transport (default)
+    python mcp_radicale_server.py
+    
+    # Run with HTTP transport
+    python mcp_radicale_server.py --transport http --port 8765
+
+Dependencies:
+    pip install mcp caldav python-dotenv
+"""
+
+import os
+import json
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from typing import Optional, List, Dict, Any
+from dotenv import load_dotenv
+
+# MCP imports
+try:
+    from mcp.server.fastmcp import FastMCP
+    from mcp.types import Tool, TextContent
+except ImportError:
+    print("MCP package not found. Please install with: pip install mcp")
+    exit(1)
+
+# Local imports
+from radicale_calendar_manager import RadicaleCalendarManager
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger("mcp-radicale-server")
+
+# Load environment variables
+load_dotenv()
+
+class MCPError(Exception):
+    """Custom exception for MCP operations"""
+    pass
+
+class MCPRadicaleServer:
+    """
+    MCP-compliant server for Radicale calendar operations.
+    
+    This class implements a FastMCP server that provides calendar operations
+    as MCP tools. It handles connection management, tool registration, and
+    provides async operations for calendar management.
+    """
+    
+    def __init__(self):
+        """Initialize the MCP server with calendar manager and tool registration"""
+        self.mcp = FastMCP("RadicaleCalendar")
+        self.calendar_manager = None
+        self._initialize_calendar_manager()
+        self._register_tools()
+        
+    def _initialize_calendar_manager(self):
+        """Initialize the Radicale calendar manager with environment configuration"""
+        try:
+            radicale_url = os.getenv("RADICALE_URL", "http://localhost:5232")
+            radicale_username = os.getenv("RADICALE_USERNAME", "")
+            radicale_password = os.getenv("RADICALE_PASSWORD", "")
+            
+            if not radicale_username or not radicale_password:
+                logger.warning("Radicale credentials not found in environment variables")
+                
+            self.calendar_manager = RadicaleCalendarManager(
+                url=radicale_url,
+                username=radicale_username,
+                password=radicale_password
+            )
+            
+            # Test connection during initialization
+            if not self.calendar_manager.connect():
+                raise MCPError("Failed to connect to Radicale server during initialization")
+                
+            logger.info(f"Successfully connected to Radicale server at {radicale_url}")
+            
+        except Exception as e:
+            logger.error(f"Failed to initialize calendar manager: {e}")
+            raise MCPError(f"Calendar manager initialization failed: {e}")
+    
+    def _register_tools(self):
+        """Register all calendar tools with the MCP server"""
+        
+        @self.mcp.tool()
+        async def list_calendars() -> str:
+            """
+            List all available calendars in the Radicale server.
+            
+            Returns:
+                JSON string containing list of calendar names
+                
+            Example:
+                ["Personal", "Work", "Family"]
+            """
+            try:
+                if not self.calendar_manager or not self.calendar_manager.calendars:
+                    # Reconnect if needed
+                    if not self.calendar_manager.connect():
+                        raise MCPError("Failed to connect to Radicale server")
+                
+                calendar_names = [cal.name for cal in self.calendar_manager.calendars]
+                logger.info(f"Listed {len(calendar_names)} calendars")
+                
+                return json.dumps({
+                    "status": "success",
+                    "calendars": calendar_names,
+                    "count": len(calendar_names)
+                })
+                
+            except Exception as e:
+                logger.error(f"Error listing calendars: {e}")
+                raise MCPError(f"Failed to list calendars: {e}")
+        
+        @self.mcp.tool()
+        async def get_events(
+            calendar_name: Optional[str] = None,
+            start_date: Optional[str] = None,
+            end_date: Optional[str] = None
+        ) -> str:
+            """
+            Get events from a calendar within a specified date range.
+            
+            Args:
+                calendar_name: Name of the calendar (optional, uses first available if not specified)
+                start_date: Start date in ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
+                end_date: End date in ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
+                
+            Returns:
+                JSON string containing list of events with their details
+                
+            Example:
+                {
+                    "status": "success",
+                    "calendar": "Work",
+                    "events": [
+                        {
+                            "id": "event-123",
+                            "summary": "Team Meeting",
+                            "start": "2023-06-01T10:00:00",
+                            "end": "2023-06-01T11:00:00",
+                            "location": "Conference Room",
+                            "description": "Weekly team sync"
+                        }
+                    ],
+                    "count": 1
+                }
+            """
+            try:
+                # Parse date parameters
+                start_dt = None
+                end_dt = None
+                
+                if start_date:
+                    try:
+                        start_dt = datetime.fromisoformat(start_date.replace('Z', '+00:00'))
+                    except ValueError:
+                        raise MCPError(f"Invalid start_date format: {start_date}. Use ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)")
+                
+                if end_date:
+                    try:
+                        end_dt = datetime.fromisoformat(end_date.replace('Z', '+00:00'))
+                    except ValueError:
+                        raise MCPError(f"Invalid end_date format: {end_date}. Use ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)")
+                
+                # Get events
+                events = self.calendar_manager.get_events(calendar_name, start_dt, end_dt)
+                
+                # Determine which calendar was used
+                used_calendar = calendar_name
+                if not used_calendar and self.calendar_manager.calendars:
+                    used_calendar = self.calendar_manager.calendars[0].name
+                
+                logger.info(f"Retrieved {len(events)} events from calendar '{used_calendar}'")
+                
+                return json.dumps({
+                    "status": "success",
+                    "calendar": used_calendar,
+                    "events": events,
+                    "count": len(events),
+                    "date_range": {
+                        "start": start_date,
+                        "end": end_date
+                    }
+                })
+                
+            except MCPError:
+                raise
+            except Exception as e:
+                logger.error(f"Error getting events: {e}")
+                raise MCPError(f"Failed to get events: {e}")
+        
+        @self.mcp.tool()
+        async def create_event(
+            calendar_name: str,
+            summary: str,
+            start: str,
+            end: Optional[str] = None,
+            location: Optional[str] = None,
+            description: Optional[str] = None
+        ) -> str:
+            """
+            Create a new calendar event.
+            
+            Args:
+                calendar_name: Name of the calendar to create the event in
+                summary: Event title/summary (required)
+                start: Start datetime in ISO format (YYYY-MM-DDTHH:MM:SS) (required)
+                end: End datetime in ISO format (optional, defaults to start + 1 hour)
+                location: Event location (optional)
+                description: Event description (optional)
+                
+            Returns:
+                JSON string with created event details and ID
+                
+            Example:
+                {
+                    "status": "success",
+                    "message": "Event 'Team Meeting' created successfully",
+                    "event_id": "event-123",
+                    "calendar": "Work"
+                }
+            """
+            try:
+                # Validate required fields
+                if not summary.strip():
+                    raise MCPError("Event summary is required and cannot be empty")
+                
+                if not start.strip():
+                    raise MCPError("Event start time is required and cannot be empty")
+                
+                # Validate start time format
+                try:
+                    datetime.fromisoformat(start.replace('Z', '+00:00'))
+                except ValueError:
+                    raise MCPError(f"Invalid start time format: {start}. Use ISO format (YYYY-MM-DDTHH:MM:SS)")
+                
+                # Validate end time format if provided
+                if end:
+                    try:
+                        datetime.fromisoformat(end.replace('Z', '+00:00'))
+                    except ValueError:
+                        raise MCPError(f"Invalid end time format: {end}. Use ISO format (YYYY-MM-DDTHH:MM:SS)")
+                
+                # Prepare event data
+                event_data = {
+                    "summary": summary,
+                    "start": start
+                }
+                
+                if end:
+                    event_data["end"] = end
+                if location:
+                    event_data["location"] = location
+                if description:
+                    event_data["description"] = description
+                
+                # Create the event
+                event_id = self.calendar_manager.add_event(calendar_name, event_data)
+                
+                logger.info(f"Created event '{summary}' with ID '{event_id}' in calendar '{calendar_name}'")
+                
+                return json.dumps({
+                    "status": "success",
+                    "message": f"Event '{summary}' created successfully",
+                    "event_id": event_id,
+                    "calendar": calendar_name,
+                    "event_data": event_data
+                })
+                
+            except MCPError:
+                raise
+            except Exception as e:
+                logger.error(f"Error creating event: {e}")
+                raise MCPError(f"Failed to create event: {e}")
+        
+        @self.mcp.tool()
+        async def update_event(
+            calendar_name: str,
+            event_id: str,
+            summary: Optional[str] = None,
+            start: Optional[str] = None,
+            end: Optional[str] = None,
+            location: Optional[str] = None,
+            description: Optional[str] = None
+        ) -> str:
+            """
+            Update an existing calendar event.
+            
+            Args:
+                calendar_name: Name of the calendar containing the event
+                event_id: ID of the event to update (required)
+                summary: New event title/summary (optional)
+                start: New start datetime in ISO format (optional)
+                end: New end datetime in ISO format (optional)
+                location: New event location (optional)
+                description: New event description (optional)
+                
+            Returns:
+                JSON string with update status
+                
+            Example:
+                {
+                    "status": "success",
+                    "message": "Event 'event-123' updated successfully",
+                    "event_id": "event-123",
+                    "updated_fields": ["summary", "location"]
+                }
+            """
+            try:
+                # Validate required fields
+                if not event_id.strip():
+                    raise MCPError("Event ID is required and cannot be empty")
+                
+                # Validate date formats if provided
+                if start:
+                    try:
+                        datetime.fromisoformat(start.replace('Z', '+00:00'))
+                    except ValueError:
+                        raise MCPError(f"Invalid start time format: {start}. Use ISO format (YYYY-MM-DDTHH:MM:SS)")
+                
+                if end:
+                    try:
+                        datetime.fromisoformat(end.replace('Z', '+00:00'))
+                    except ValueError:
+                        raise MCPError(f"Invalid end time format: {end}. Use ISO format (YYYY-MM-DDTHH:MM:SS)")
+                
+                # Prepare update data (only include non-None values)
+                update_data = {}
+                updated_fields = []
+                
+                if summary is not None:
+                    update_data["summary"] = summary
+                    updated_fields.append("summary")
+                if start is not None:
+                    update_data["start"] = start
+                    updated_fields.append("start")
+                if end is not None:
+                    update_data["end"] = end
+                    updated_fields.append("end")
+                if location is not None:
+                    update_data["location"] = location
+                    updated_fields.append("location")
+                if description is not None:
+                    update_data["description"] = description
+                    updated_fields.append("description")
+                
+                if not update_data:
+                    raise MCPError("At least one field must be provided for update")
+                
+                # Update the event
+                success = self.calendar_manager.set_event(calendar_name, event_id, update_data)
+                
+                if success:
+                    logger.info(f"Updated event '{event_id}' in calendar '{calendar_name}'. Fields: {updated_fields}")
+                    return json.dumps({
+                        "status": "success",
+                        "message": f"Event '{event_id}' updated successfully",
+                        "event_id": event_id,
+                        "calendar": calendar_name,
+                        "updated_fields": updated_fields,
+                        "update_data": update_data
+                    })
+                else:
+                    raise MCPError(f"Failed to update event '{event_id}' - event may not exist")
+                    
+            except MCPError:
+                raise
+            except Exception as e:
+                logger.error(f"Error updating event: {e}")
+                raise MCPError(f"Failed to update event: {e}")
+        
+        @self.mcp.tool()
+        async def delete_event(calendar_name: str, event_id: str) -> str:
+            """
+            Delete a calendar event.
+            
+            Args:
+                calendar_name: Name of the calendar containing the event
+                event_id: ID of the event to delete (required)
+                
+            Returns:
+                JSON string with deletion status
+                
+            Example:
+                {
+                    "status": "success",
+                    "message": "Event 'event-123' deleted successfully",
+                    "event_id": "event-123",
+                    "calendar": "Work"
+                }
+            """
+            try:
+                # Validate required fields
+                if not event_id.strip():
+                    raise MCPError("Event ID is required and cannot be empty")
+                
+                if not calendar_name.strip():
+                    raise MCPError("Calendar name is required and cannot be empty")
+                
+                # Delete the event
+                success = self.calendar_manager.delete_event(calendar_name, event_id)
+                
+                if success:
+                    logger.info(f"Deleted event '{event_id}' from calendar '{calendar_name}'")
+                    return json.dumps({
+                        "status": "success",
+                        "message": f"Event '{event_id}' deleted successfully",
+                        "event_id": event_id,
+                        "calendar": calendar_name
+                    })
+                else:
+                    raise MCPError(f"Failed to delete event '{event_id}' - event may not exist")
+                    
+            except MCPError:
+                raise
+            except Exception as e:
+                logger.error(f"Error deleting event: {e}")
+                raise MCPError(f"Failed to delete event: {e}")
+    
+    async def run_server(self, transport="stdio", port=8765):
+        """
+        Run the MCP server with specified transport method.
+        
+        Args:
+            transport: Transport method ("stdio" or "sse")
+            port: Port number for SSE transport (default: 8765)
+        """
+        logger.info(f"Starting MCP Radicale server with {transport} transport")
+        
+        try:
+            if transport == "stdio":
+                logger.info("Running MCP server with stdio transport")
+                await self.mcp.run_stdio_async()
+            elif transport == "http" or transport == "sse":
+                logger.info(f"Running MCP server with SSE transport on port {port}")
+                # Get the SSE app and run it with uvicorn
+                import uvicorn
+                app = self.mcp.sse_app()
+                config = uvicorn.Config(app, host="localhost", port=port, log_level="info")
+                server = uvicorn.Server(config)
+                await server.serve()
+            else:
+                raise ValueError(f"Unsupported transport: {transport}. Use 'stdio' or 'sse'")
+                
+        except Exception as e:
+            logger.error(f"Error running MCP server: {e}")
+            raise
+
+def main():
+    """Main entry point for the MCP server"""
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="MCP Radicale Calendar Server")
+    parser.add_argument(
+        "--transport", 
+        choices=["stdio", "http", "sse"], 
+        default="stdio",
+        help="Transport method for MCP communication (default: stdio)"
+    )
+    parser.add_argument(
+        "--port", 
+        type=int, 
+        default=8765,
+        help="Port number for HTTP transport (default: 8765)"
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Logging level (default: INFO)"
+    )
+    
+    args = parser.parse_args()
+    
+    # Set logging level
+    logging.getLogger().setLevel(getattr(logging, args.log_level))
+    
+    # Create and run server
+    server = MCPRadicaleServer()
+    
+    try:
+        asyncio.run(server.run_server(transport=args.transport, port=args.port))
+    except KeyboardInterrupt:
+        logger.info("Server stopped by user")
+    except Exception as e:
+        logger.error(f"Server error: {e}")
+        exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Essential files for LangChain MCP calendar integration:
- langchain_example_mcp.py: Main example with OpenAI and local LLM support
- langchain_mcp_integration.py: MCP integration layer with automatic fallbacks
- mcp_radicale_server.py: MCP server implementation for Radicale
- README.md: Condensed setup guide with apt-based Radicale installation
- Uses existing radicale_calendar_manager.py for core calendar operations

Features:
- Natural language calendar operations ("Schedule meeting tomorrow at 2pm")
- Automatic fallback from MCP packages to manual tools
- Support for both OpenAI and local LLMs (Ollama)
- Simple apt-based Radicale server setup with htpasswd authentication
- Minimal dependencies and configuration

Setup includes:
- Radicale installation via apt
- htpasswd authentication configuration
- User creation with apache2-utils
- Environment variable configuration

🤖 Generated with [Claude Code](https://claude.ai/code)