### PR TITLE
reformat `radicale-container/docker-compose.yml`

### DIFF
--- a/radicale-container/docker-compose.yml
+++ b/radicale-container/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   radicale:
     build: .


### PR DESCRIPTION
Exactly what it says on the tin. Apparently Prettier does not like single quotes.

(I did this after noticing that Prettier failed yet again on [this PR](https://github.com/SGIARK/ARK2.0/pull/40).)