### PR TITLE
Add docker infrastructure for SGLang, TEI, and Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,46 @@
-# Database Connection (REQUIRED)
-# Format: postgresql://user:password@host:port/database
-DB_URL=
+# ===========================================
+# Database / Supabase
+# ===========================================
+POSTGRES_PASSWORD=postgres
+JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters
 
-# Hugging Face Token (OPTIONAL - for gated models)
+# Supabase keys (generate these or use defaults for local dev)
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_KEY=
+
+# Auth settings
+SITE_URL=http://localhost:3000
+API_EXTERNAL_URL=http://localhost:9999
+ADDITIONAL_REDIRECT_URLS=
+DISABLE_SIGNUP=false
+ENABLE_EMAIL_SIGNUP=true
+ENABLE_EMAIL_AUTOCONFIRM=true
+ENABLE_ANONYMOUS_USERS=false
+
+# ===========================================
+# SGLang - LLM Inference
+# ===========================================
+# Model to load
+SGLANG_MODEL=Qwen/Qwen2.5-7B-Instruct
+
+# ===========================================
+# Huggingface Text Embeddings Inference
+# ===========================================
+# Embedding model to use
+TEI_MODEL=BAAI/bge-small-en-v1.5
+
+# ===========================================
+# API Keys
+# ===========================================
+# Hugging Face Token (required for gated models like Llama)
 HF_TOKEN=
 
-# MCP Server Credentials (OPTIONAL - for tool integrations)
+# OpenAI API Key (required by mem0, but not actually used)
+OPENAI_API_KEY=
+
+# ===========================================
+# MCP Server Credentials (optional)
+# ===========================================
 GOOGLE_OAUTH_CREDENTIALS=
 GOOGLE_CALENDAR_MCP_TOKEN_PATH=
 BRAVE_API_KEY=
-
-# OpenAI API Key (REQUIRED by mem0, but not used)
-OPENAI_API_KEY=
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,205 @@
+version: "3.8"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "1112:1112"
+    environment:
+      - DB_URL=postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@supabase-db:5432/postgres
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-sk-dummy}
+      - HF_TOKEN=${HF_TOKEN:-}
+      - SGLANG_URL=http://sglang:30000
+      - TEI_URL=http://tei:80
+      - SUPABASE_URL=http://supabase-rest:3000
+      - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY:-}
+    env_file:
+      - .env
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+      sglang:
+        condition: service_started
+      tei:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - arkos-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:1112/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  # ============================================
+  # SGLang - LLM Inference Server
+  # ============================================
+  sglang:
+    image: lmsysorg/sglang:latest
+    ports:
+      - "30000:30000"
+    environment:
+      - HF_TOKEN=${HF_TOKEN:-}
+    volumes:
+      - sglang_cache:/root/.cache/huggingface
+    command: >
+      python -m sglang.launch_server
+      --model-path ${SGLANG_MODEL:-Qwen/Qwen2.5-7B-Instruct}
+      --host 0.0.0.0
+      --port 30000
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    restart: unless-stopped
+    networks:
+      - arkos-network
+
+  # ============================================
+  # Huggingface Text Embeddings Inference
+  # ============================================
+  tei:
+    image: ghcr.io/huggingface/text-embeddings-inference:1.5
+    ports:
+      - "8081:80"
+    environment:
+      - HF_TOKEN=${HF_TOKEN:-}
+    volumes:
+      - tei_cache:/data
+    command: >
+      --model-id ${TEI_MODEL:-BAAI/bge-small-en-v1.5}
+      --port 80
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    restart: unless-stopped
+    networks:
+      - arkos-network
+
+  # ============================================
+  # Supabase Services
+  # ============================================
+  supabase-db:
+    image: supabase/postgres:15.6.1.143
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: postgres
+      JWT_SECRET: ${JWT_SECRET:-super-secret-jwt-token-with-at-least-32-characters}
+      JWT_EXP: 3600
+    volumes:
+      - supabase_db_data:/var/lib/postgresql/data
+      - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - arkos-network
+
+  supabase-auth:
+    image: supabase/gotrue:v2.164.0
+    ports:
+      - "9999:9999"
+    environment:
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: 9999
+      API_EXTERNAL_URL: ${API_EXTERNAL_URL:-http://localhost:9999}
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@supabase-db:5432/postgres?search_path=auth
+      GOTRUE_SITE_URL: ${SITE_URL:-http://localhost:3000}
+      GOTRUE_URI_ALLOW_LIST: ${ADDITIONAL_REDIRECT_URLS:-}
+      GOTRUE_DISABLE_SIGNUP: ${DISABLE_SIGNUP:-false}
+      GOTRUE_JWT_ADMIN_ROLES: service_role
+      GOTRUE_JWT_AUD: authenticated
+      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      GOTRUE_JWT_EXP: 3600
+      GOTRUE_JWT_SECRET: ${JWT_SECRET:-super-secret-jwt-token-with-at-least-32-characters}
+      GOTRUE_EXTERNAL_EMAIL_ENABLED: ${ENABLE_EMAIL_SIGNUP:-true}
+      GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED: ${ENABLE_ANONYMOUS_USERS:-false}
+      GOTRUE_MAILER_AUTOCONFIRM: ${ENABLE_EMAIL_AUTOCONFIRM:-true}
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - arkos-network
+
+  supabase-rest:
+    image: postgrest/postgrest:v12.2.3
+    ports:
+      - "3001:3000"
+    environment:
+      PGRST_DB_URI: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@supabase-db:5432/postgres
+      PGRST_DB_SCHEMAS: public,storage,graphql_public
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${JWT_SECRET:-super-secret-jwt-token-with-at-least-32-characters}
+      PGRST_DB_USE_LEGACY_GUCS: "false"
+      PGRST_APP_SETTINGS_JWT_SECRET: ${JWT_SECRET:-super-secret-jwt-token-with-at-least-32-characters}
+      PGRST_APP_SETTINGS_JWT_EXP: 3600
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - arkos-network
+
+  supabase-storage:
+    image: supabase/storage-api:v1.11.13
+    ports:
+      - "5000:5000"
+    environment:
+      ANON_KEY: ${SUPABASE_ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0}
+      SERVICE_KEY: ${SUPABASE_SERVICE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU}
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@supabase-db:5432/postgres
+      FILE_SIZE_LIMIT: 52428800
+      STORAGE_BACKEND: file
+      FILE_STORAGE_BACKEND_PATH: /var/lib/storage
+      TENANT_ID: stub
+      REGION: stub
+      GLOBAL_S3_BUCKET: stub
+      ENABLE_IMAGE_TRANSFORMATION: "true"
+      IMGPROXY_URL: http://supabase-imgproxy:8080
+      PGRST_JWT_SECRET: ${JWT_SECRET:-super-secret-jwt-token-with-at-least-32-characters}
+      POSTGREST_URL: http://supabase-rest:3000
+      AUTH_JWT_SECRET: ${JWT_SECRET:-super-secret-jwt-token-with-at-least-32-characters}
+      AUTH_JWT_ALGORITHM: HS256
+    volumes:
+      - supabase_storage_data:/var/lib/storage
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+      supabase-rest:
+        condition: service_started
+    restart: unless-stopped
+    networks:
+      - arkos-network
+
+volumes:
+  supabase_db_data:
+  supabase_storage_data:
+  sglang_cache:
+  tei_cache:
+
+networks:
+  arkos-network:
+    driver: bridge


### PR DESCRIPTION
## What's this PR about

We needed a way to spin up the full inference stack locally without installing a bunch of stuff manually. This PR adds docker containers for the ML services and replaces the basic postgres with Supabase.

## Services added

| Service | Port | Description |
|---------|------|-------------|
| `sglang` | 30000 | LLM inference, defaults to Qwen2.5-7B |
| `tei` | 8081 | Huggingface text embeddings (BGE small) |
| `supabase-db` | 5432 | Postgres with Supabase extensions |
| `supabase-auth` | 9999 | Authentication via GoTrue |
| `supabase-rest` | 3001 | PostgREST for auto-generated REST API |
| `supabase-storage` | 5000 | File storage |

## How it works

Everything runs on a shared docker network so services can talk to each other by name. The main app waits for the database and TEI to be healthy before starting, and SGLang just needs to be running (no health endpoint).

Both SGLang and TEI are configured to use GPU. If you dont have a GPU this wont work out of the box - you'd need to swap TEI back to the cpu image and figure out something for SGLang (maybe use a different backend).

## Environment variables

Updated `.env.example` with all the new config options. Most things have sane defaults so you can just `cp .env.example .env` and run it.

The default model is Qwen2.5-7B-Instruct which doesn't require a HF token since its not gated.

## Running it

```bash
cp .env.example .env
docker-compose up --build
```

Then the API is at http://localhost:1112

## Notes

- Supabase keys in env.example are demo keys, generate proper ones for anything beyond local dev
- SGLang needs nvidia-docker setup, wont start without GPU
- TEI health check has a longer start period (60s) cuz it downloads the model on first run
- Storage uses local filesystem, not S3

Let me know if anything needs adjusting