### PR TITLE
add StateOutput model to state_module/base_state.py

### DIFF
--- a/state_module/base_state.py
+++ b/state_module/base_state.py
@@ -1,0 +1,12 @@
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel
+
+
+class StateOutput(BaseModel):
+    # content is Optional: edge case where the model returns nothing should not crash the loop
+    content: Optional[str] = None
+    completion_signal: Literal["complete", "incomplete", "error", "needs_input"]
+    # dict[str, Any]: tool and reasoning results are heterogeneous JSON objects
+    structured_data: Optional[dict[str, Any]] = None
+    error_detail: Optional[str] = None

--- a/tests/test_base_state.py
+++ b/tests/test_base_state.py
@@ -1,0 +1,41 @@
+"""Tests for state_module/base_state.py: StateOutput model."""
+
+import pytest
+from pydantic import ValidationError
+
+from state_module.base_state import StateOutput
+
+
+class TestStateOutput:
+    def test_acceptance_test(self):
+        """Reproduces the acceptance test from the issue verbatim."""
+        result = StateOutput(content="ok", completion_signal="complete")
+        assert result.content == "ok"
+        assert result.completion_signal == "complete"
+
+    def test_content_is_optional(self):
+        """content=None is valid: model returning nothing must not crash the loop."""
+        result = StateOutput(completion_signal="error")
+        assert result.content is None
+
+    def test_defaults(self):
+        """structured_data and error_detail default to None."""
+        result = StateOutput(completion_signal="incomplete")
+        assert result.structured_data is None
+        assert result.error_detail is None
+
+    def test_all_completion_signals_accepted(self):
+        """All four valid signals are accepted; documents the allowed enum."""
+        for signal in ("complete", "incomplete", "error", "needs_input"):
+            result = StateOutput(completion_signal=signal)
+            assert result.completion_signal == signal
+
+    def test_invalid_completion_signal_rejected(self):
+        """Literal constraint is enforced — unknown signals are rejected."""
+        with pytest.raises(ValidationError):
+            StateOutput(completion_signal="unknown")
+
+    def test_completion_signal_required(self):
+        """completion_signal has no default; callers must always declare intent."""
+        with pytest.raises(ValidationError):
+            StateOutput(content="hello")


### PR DESCRIPTION
Introduces StateOutput, a Pydantic model that gives state.run() a typed return contract.

Design notes:
- content is Optional[str] so the loop does not crash when the model returns nothing (edge case confirmed during design review)
- completion_signal is required with no default; callers must always declare intent explicitly
- structured_data typed as dict[str, Any] — tool and reasoning results are heterogeneous JSON objects (Any is justified by comment)
- error_detail is Optional[str] for machine-readable error context

Note: state_module/state.py already exists as the State base class. base_state.py is a new file that holds only the output contract model, keeping the two concerns separate.

Closes #156