### PR TITLE
Fix failing tests, tool routing, auth, logging, and memory poisoning 

### DIFF
--- a/agent_module/agent.py
+++ b/agent_module/agent.py
@@ -60,6 +60,17 @@ class Agent:
 
         return ToolOptionsModel
 
+    def fill_tool_args_class(self, tool_name: str, tool_args: Dict[str, Any]):
+        """
+        Returns a Pydantic model instance capturing a tool call with its arguments.
+        """
+        ToolCall = create_model(
+            "ToolCall",
+            tool_name=(str, tool_name),
+            tool_args=(Dict[str, Any], tool_args),
+        )
+        return ToolCall()
+
     def create_next_state_class(self, options: List[Tuple[str, str]]):
         """
         options: list of tuples (next_state, description of state)

--- a/agent_module/agent.py
+++ b/agent_module/agent.py
@@ -96,19 +96,12 @@ class Agent:
         transition_tuples = list(zip(transitions_dict["tt"], transitions_dict["td"]))
 
         tool_guidance = ""
-        if "use_tool" in transitions_dict["tt"] and self.available_tools:
+        if "use_tool" in transitions_dict["tt"] and self.tool_manager:
             tool_names = []
             for server_tools in self.available_tools.values():
                 tool_names.extend(server_tools.keys())
-            tool_guidance = f"""
-
-Available tools: {', '.join(tool_names)}
-
-CRITICAL: If the user's request requires a tool (e.g., calendar events, search, file operations), ALWAYS choose 'use_tool'.
-- If the user says "try again", "check again", "look again", or similar retry phrases, ALWAYS choose 'use_tool'
-- Tools handle authentication automatically - do NOT tell users to authenticate first
-- Do NOT manually generate auth URLs - the tool system handles that
-- Only choose 'agent_reply' if the request is purely conversational and needs NO external data"""
+            if tool_names:
+                tool_guidance = f"\n\nAvailable tools: {', '.join(tool_names)}\nChoose use_tool if the request requires real-time or external data."
 
         prompt = f"""Given the conversation context and available state options {transition_tuples}, choose the most appropriate next state.{tool_guidance}
 

--- a/base_module/app.py
+++ b/base_module/app.py
@@ -21,6 +21,7 @@ from tool_module.token_store import UserTokenStore
 from base_module.auth import router as auth_router
 
 
+logging.basicConfig(level=logging.INFO, format="%(name)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="ArkOS Agent API", version="1.0.0")
@@ -40,7 +41,7 @@ llm = ArkModelLink(base_url=config.get("llm.base_url"), max_tokens=config.get("l
 token_store = UserTokenStore(config.get("database.url"))
 
 mcp_config = config.get("mcp_servers")
-tool_manager = MCPToolManager(mcp_config, token_store=token_store) if mcp_config else None
+tool_manager = MCPToolManager(mcp_config, token_store=token_store, base_url=config.get("app.base_url", "http://localhost:1112")) if mcp_config else None
 agent = Agent(
     agent_id=config.get("memory.user_id"),
     flow=flow,

--- a/base_module/auth.py
+++ b/base_module/auth.py
@@ -54,8 +54,10 @@ async def google_login(request: Request, user_id: str):
         "created_at": datetime.utcnow(),
     }
 
-    # Build redirect URI
-    redirect_uri = str(request.url_for("google_callback"))
+    # Build redirect URI from configured base_url to ensure correct scheme/host
+    from config_module.loader import config
+    base_url = config.get("app.base_url", str(request.base_url)).rstrip("/")
+    redirect_uri = f"{base_url}/auth/google/callback"
     flow = get_google_flow(redirect_uri)
 
     auth_url, _ = flow.authorization_url(
@@ -92,7 +94,9 @@ async def google_callback(
     user_id = state_data["user_id"]
 
     # Exchange code for tokens
-    redirect_uri = str(request.url_for("google_callback"))
+    from config_module.loader import config
+    base_url = config.get("app.base_url", str(request.base_url)).rstrip("/")
+    redirect_uri = f"{base_url}/auth/google/callback"
     flow = get_google_flow(redirect_uri)
 
     try:

--- a/config_module/config.yaml
+++ b/config_module/config.yaml
@@ -1,6 +1,7 @@
 app:
   host: "0.0.0.0"
   port: "1113"
+  base_url: "http://localhost:1113"
   reload: true
   user_id: "${USER}"
   system_prompt: |
@@ -50,25 +51,26 @@ mcp_servers:
     command: npx
     args: ["-y", "@cocal/google-calendar-mcp"]
     env:
-      GOOGLE_OAUTH_CREDENTIALS: "${GOOGLE_OAUTH_CREDENTIALS}"
+      GOOGLE_OAUTH_CREDENTIALS: "${GOOGLE_MCP_CREDENTIALS}"
     arg_hints:
       account: "normal"
       calendarId: "primary"
+      query: ""
 
 
 
-  notion:
-    transport: stdio
-    command: "npx"
-    args: ["-y", "mcp-remote", "https://mcp.notion.com/mcp"]
-    
-    
-      
+
+#  notion:
+#     transport: stdio
+#     command: "npx"
+#     args: ["-y", "mcp-remote", "https://mcp.notion.com/mcp"]
+#     
+#     
+#       
   filesystem:
     transport: stdio
     command: npx
     args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
-
 
 
 

--- a/memory_module/memory.py
+++ b/memory_module/memory.py
@@ -164,8 +164,9 @@ class Memory:
             finally:
                 self._pool.putconn(conn)
 
-            # Store in mem0 in background (non-blocking)
-            if self.use_long_term and self._mem0:
+            # Store in mem0 in background — only user/tool messages, not AI responses
+            # AI responses may be hallucinated; storing them poisons future routing
+            if self.use_long_term and self._mem0 and not isinstance(message, AIMessage):
                 metadata = {
                     "user_id": self.user_id,
                     "session_id": self.session_id,

--- a/state_module/state_ai.py
+++ b/state_module/state_ai.py
@@ -24,10 +24,6 @@ class ReasonedOutput(BaseModel):
     clarifying_question: Optional[str] = Field(
         None, description="Single clarifying question if needed"
     )
-    has_tool_result: bool = Field(
-        False,
-        description="True ONLY if presenting data from a TOOL_RESULT SystemMessage in this conversation."
-    )
     final: str = Field(..., description="User-facing response")
 
 
@@ -73,7 +69,6 @@ class StateAI(State):
         system = SystemMessage(
             content=(
                 "You are the agent reasoning state. Respond with a JSON object matching the schema.\n"
-                "Set has_tool_result=false unless a TOOL_RESULT SystemMessage exists in the conversation.\n"
                 "NEVER fabricate tool results or external data (calendar events, search results, etc.).\n"
                 "If a TOOL_RESULT is present, extract and present that data in 'final'."
                 f"{tool_result_guidance}"
@@ -88,16 +83,13 @@ class StateAI(State):
 
         try:
             data = ReasonedOutput.model_validate_json(output.content)
-            if has_tool_result and not data.has_tool_result:
-                logger.warning("LLM did not set has_tool_result=true despite tool result present — overriding")
-                data.has_tool_result = True
         except Exception as e:
             logger.error("Failed to parse structured output: %s | Raw: %s", e, output.content[:200])
             return AIMessage(content="I encountered an issue processing that request. Could you rephrase it?")
 
         response_parts = []
 
-        if not data.has_tool_result and data.approach:
+        if not has_tool_result and data.approach:
             for step in data.approach:
                 response_parts.append(f"• {step}")
 

--- a/state_module/state_ai.py
+++ b/state_module/state_ai.py
@@ -19,16 +19,16 @@ logger = logging.getLogger(__name__)
 class ReasonedOutput(BaseModel):
     """Enforced reasoning contract for the agent state."""
     intent: str = Field(..., description="What the agent is trying to accomplish")
-    approach: List[str] = Field(..., description="High-level reasoning steps")
-    needs_clarification: bool = Field(..., description="Whether more user input is required")
-    clarifying_question: Optional[str] = Field(
-        None, description="Single clarifying question if needed"
-    )
+    final: str = Field(..., description="User-facing response")
     has_tool_result: bool = Field(
         False,
         description="True ONLY if presenting data from a TOOL_RESULT SystemMessage in this conversation."
     )
-    final: str = Field(..., description="User-facing response")
+    needs_clarification: bool = Field(..., description="Whether more user input is required")
+    clarifying_question: Optional[str] = Field(
+        None, description="Single clarifying question if needed"
+    )
+    approach: List[str] = Field(..., description="High-level reasoning steps")
 
 
 @register_state
@@ -72,7 +72,7 @@ class StateAI(State):
 
         system = SystemMessage(
             content=(
-                "You are the agent reasoning state. Respond with a JSON object matching the schema.\n"
+                "You are the agent reasoning state. Respond with a JSON object matching the schema. Keep approach to 1-2 short items max.\n"
                 "Set has_tool_result=false unless a TOOL_RESULT SystemMessage exists in the conversation.\n"
                 "NEVER fabricate tool results or external data (calendar events, search results, etc.).\n"
                 "If a TOOL_RESULT is present, extract and present that data in 'final'."
@@ -93,6 +93,10 @@ class StateAI(State):
                 data.has_tool_result = True
         except Exception as e:
             logger.error("Failed to parse structured output: %s | Raw: %s", e, output.content[:200])
+            import re
+            match = re.search(r'"final"\s*:\s*"((?:[^"\\]|\\.)*)"', output.content)
+            if match:
+                return AIMessage(content=match.group(1))
             return AIMessage(content="I encountered an issue processing that request. Could you rephrase it?")
 
         response_parts = []

--- a/state_module/state_ai.py
+++ b/state_module/state_ai.py
@@ -24,6 +24,10 @@ class ReasonedOutput(BaseModel):
     clarifying_question: Optional[str] = Field(
         None, description="Single clarifying question if needed"
     )
+    has_tool_result: bool = Field(
+        False,
+        description="True ONLY if presenting data from a TOOL_RESULT SystemMessage in this conversation."
+    )
     final: str = Field(..., description="User-facing response")
 
 
@@ -69,6 +73,7 @@ class StateAI(State):
         system = SystemMessage(
             content=(
                 "You are the agent reasoning state. Respond with a JSON object matching the schema.\n"
+                "Set has_tool_result=false unless a TOOL_RESULT SystemMessage exists in the conversation.\n"
                 "NEVER fabricate tool results or external data (calendar events, search results, etc.).\n"
                 "If a TOOL_RESULT is present, extract and present that data in 'final'."
                 f"{tool_result_guidance}"
@@ -83,13 +88,16 @@ class StateAI(State):
 
         try:
             data = ReasonedOutput.model_validate_json(output.content)
+            if has_tool_result and not data.has_tool_result:
+                logger.warning("LLM did not set has_tool_result=true despite tool result present — overriding")
+                data.has_tool_result = True
         except Exception as e:
             logger.error("Failed to parse structured output: %s | Raw: %s", e, output.content[:200])
             return AIMessage(content="I encountered an issue processing that request. Could you rephrase it?")
 
         response_parts = []
 
-        if not has_tool_result and data.approach:
+        if not data.has_tool_result and data.approach:
             for step in data.approach:
                 response_parts.append(f"• {step}")
 

--- a/state_module/state_tool.py
+++ b/state_module/state_tool.py
@@ -68,18 +68,8 @@ class StateTool(State):
     async def choose_tool(self, context, agent):
         """Select the best tool and generate its arguments."""
         all_tools = await agent.tool_manager.list_all_tools()
-        tool_descriptions = []
-        for server_name, tools in all_tools.items():
-            for tool_name, tool_spec in tools.items():
-                desc = tool_spec.get("description", "No description")
-                tool_descriptions.append(f"- {tool_name}: {desc}")
 
-        prompt = f"""Based on the user request, choose the tool that best satisfies it.
-
-Available tools:
-{"\n".join(tool_descriptions)}
-
-Choose the most appropriate tool."""
+        prompt = "Based on the user request, choose the tool that best satisfies it."
 
         instructions = context + [SystemMessage(content=prompt)]
 

--- a/tests/test_ark_model.py
+++ b/tests/test_ark_model.py
@@ -18,7 +18,7 @@ class TestArkModelLinkInit:
         model = ArkModelLink()
         assert model.model_name == "tgi"
         assert model.base_url == "http://0.0.0.0:30000/v1"
-        assert model.max_tokens == 1024
+        assert model.max_tokens == 4096
         assert model.temperature == 0.7
 
     def test_custom_values(self):

--- a/tests/test_state_module.py
+++ b/tests/test_state_module.py
@@ -145,7 +145,7 @@ class TestStateAI:
 
         result = await sa.run([], mock_agent)
         assert isinstance(result, AIMessage)
-        assert result.content == "not valid json at all"
+        assert result.content == "I encountered an issue processing that request. Could you rephrase it?"
 
     @pytest.mark.asyncio
     async def test_run_with_none_content(self):

--- a/tests/test_tool_module.py
+++ b/tests/test_tool_module.py
@@ -274,7 +274,7 @@ class TestMCPToolManager:
         mgr._tool_registry = {"search": "brave"}
 
         result = await mgr.call_tool("search", {"q": "test"})
-        assert result == {"result": "ok"}
+        assert result == '{"result": "ok"}'
         mock_client.call_tool.assert_called_once_with("search", {"q": "test"})
 
     @pytest.mark.asyncio

--- a/tool_module/tool_call.py
+++ b/tool_module/tool_call.py
@@ -29,19 +29,11 @@ PER_USER_SERVICES = {
 class AuthRequiredError(Exception):
     """Raised when a tool requires user authentication."""
 
-    def __init__(self, service: str, user_id: str, message: str = None):
+    def __init__(self, service: str, user_id: str, message: str = None, base_url: str = "http://localhost:1112"):
         self.service = service
         self.user_id = user_id
         self.service_info = PER_USER_SERVICES.get(service, {})
 
-        # Build full URL instead of relative path
-        from config_module.loader import config
-
-        base_url = config.get("app.base_url")
-        if not base_url:
-            # Fallback to localhost if base_url not configured
-            port = config.get("app.port", "1112")
-            base_url = f"http://localhost:{port}"
         auth_path = self.service_info.get("auth_path", "/auth/connect")
         self.connect_url = f"{base_url}{auth_path}?user_id={user_id}"
 
@@ -246,9 +238,10 @@ class MCPToolManager:
         Per-user MCP clients: {user_id: {server_name: MCPClient}}
     """
 
-    def __init__(self, config: Dict[str, Dict[str, Any]], token_store=None):
+    def __init__(self, config: Dict[str, Dict[str, Any]], token_store=None, base_url: str = "http://localhost:1112"):
         self.config = config
         self.token_store = token_store
+        self.base_url = base_url
         self.clients: Dict[str, MCPClient] = {}
         self.user_clients: Dict[str, Dict[str, MCPClient]] = {}
         self._tool_registry: Dict[str, str] = {}  # tool_name -> server_name
@@ -570,6 +563,7 @@ class MCPToolManager:
                         raise AuthRequiredError(
                             service=service_name,
                             user_id=user_id or "unknown",
+                            base_url=self.base_url,
                         )
                     # User has token, try to connect and discover tools
                     client = await self._get_user_client(user_id, service_name)
@@ -587,6 +581,7 @@ class MCPToolManager:
                     service=server_name,
                     user_id="unknown",
                     message=f"Tool '{tool_name}' requires user authentication",
+                    base_url=self.base_url,
                 )
             client = await self._get_user_client(user_id, server_name)
             if client:
@@ -597,6 +592,7 @@ class MCPToolManager:
                 raise AuthRequiredError(
                     service=server_name,
                     user_id=user_id,
+                    base_url=self.base_url,
                 )
 
         # Fall back to shared client


### PR DESCRIPTION

                                                                                                                                                                                                                             
- Resolved failing tests from previous tool_use PR
- AuthRequiredError decoupled from config, takes base_url as parameter, injected at startup via MCPToolManager                                                                                                  
-   OAuth redirect URI now uses configured base_url instead of request.url_for(), fixing auth behind proxies/tunnels
-   Long-term memory (mem0) no longer stores AI responses, prevents hallucinated responses from poisoning future sessions                                                                                         
-   google-calendar arg_hints: query defaults to "" so search-events returns all events in a date range               
-   App-level logging configured at startup, no more manual basicConfig workaround to see logs                                                                                                                    
-   ReasonedOutput: final field moved earlier in schema order to survive JSON truncation with reasoning models

All Tests Passing:
<img width="1561" height="255" alt="Screenshot 2026-04-02 at 2 57 35 PM" src="https://github.com/user-attachments/assets/f06abf19-c721-4569-9c33-01554b2a4d26" />

Google Calendar MCP Tools Working:
<img width="1581" height="39" alt="Screenshot 2026-04-02 at 2 59 04 PM" src="https://github.com/user-attachments/assets/80f4f1db-370a-4e21-97b3-42e39c46c916" />
