### PR TITLE
Vin/smithery update

### DIFF
--- a/tool_module/smithery_resolver.py
+++ b/tool_module/smithery_resolver.py
@@ -46,10 +46,10 @@ SMITHERY_API_BASE = "https://api.smithery.ai"
 # qualifiedName format is "namespace/server-name" (no leading @).
 # Add new entries here when new MCP servers are configured.
 SERVER_ID_MAP: Dict[str, str] = {
-    "google-calendar": "cocal/google-calendar-mcp",
-    "brave-search": "brave/brave-search-mcp-server",
+    "google-calendar": "googlecalendar",
+    "brave-search": "brave",
     "filesystem": "modelcontextprotocol/server-filesystem",
-    "outlook": "loopwork-ai/mcp-outlook",
+    "outlook": "outlook",
 }
 
 

--- a/tool_module/test_smithery_resolver.py
+++ b/tool_module/test_smithery_resolver.py
@@ -21,8 +21,7 @@ from tool_module.smithery_resolver import (
     SmitheryResolver,
     SmitheryResolverError,
     SERVER_ID_MAP,
-    resolve_tool_schema,
-    _get_default_resolver,
+    resolve_tool_schema
 )
 
 

--- a/tool_module/test_smithery_resolver.py
+++ b/tool_module/test_smithery_resolver.py
@@ -314,8 +314,8 @@ def test_qualified_name_normalisation():
     resolver = SmitheryResolver()
 
     # ARKOS internal name via SERVER_ID_MAP
-    assert resolver._to_qualified_name("google-calendar") == "cocal/google-calendar-mcp"
-    assert resolver._to_qualified_name("outlook") == "loopwork-ai/mcp-outlook"
+    assert resolver._to_qualified_name("google-calendar") == "googlecalendar"
+    assert resolver._to_qualified_name("outlook") == "outlook"
 
     # npm package name with leading @
     assert resolver._to_qualified_name("@cocal/google-calendar-mcp") == "cocal/google-calendar-mcp"
@@ -362,7 +362,7 @@ def test_clear_cache_forces_refetch():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
+# @pytest.mark.integration
 @pytest.mark.skipif(
     not __import__("os").environ.get("SMITHERY_API_KEY"),
     reason="SMITHERY_API_KEY not set; skipping live integration test",
@@ -375,13 +375,13 @@ def test_integration_google_calendar_live():
         SMITHERY_API_KEY=sk-... pytest tool_module/test_smithery_resolver.py \
             -m integration -v
     """
-    schema = resolve_tool_schema("google-calendar", "list_events")
+    schema = resolve_tool_schema("google-calendar", "GOOGLECALENDAR_EVENTS_LIST")
     assert isinstance(schema, dict)
     assert schema.get("type") == "object"
     assert "properties" in schema
 
 
-@pytest.mark.integration
+# @pytest.mark.integration
 @pytest.mark.skipif(
     not __import__("os").environ.get("SMITHERY_API_KEY"),
     reason="SMITHERY_API_KEY not set; skipping live integration test",


### PR DESCRIPTION
## What changed
<!-- One sentence. What does this PR do? -->
Handles the Smithery registry integration for connection to the server registry and tool schema retrieval.

## Why
<!-- One sentence. Why is this change needed? Link to task/issue if applicable. -->
Provides a dynamic way to resolve MCP tool argument schemas at runtime instead of relying on hardcoded or unknown schemas, enabling consistent tool usage.

## Type
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `test` — tests only
- [ ] `chore` — deps, config, CI, tooling
- [ ] `docs` — documentation only

## How to test
<!-- What command do you run, or what do you look at, to verify this works? -->
cd into the tool module and run:
pytest test_smithery_resolver.py

Also verify that `resolve_tool_schema("google-calendar", "list_events")` returns a valid schema dictionary without errors.