### PR TITLE
Vin/tasks table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ pip install -r requirements-dev.txt
 
 * `base_module/` -- FastAPI app, auth routes, CLI interfaces
 * `config_module/` -- YAML configuration loader
+* `db/` -- Postgress task table intializer
 * `model_module/` -- LLM inference wrapper (ArkModelLink)
 * `agent_module/` -- agent orchestration and state machine runner
 * `state_module/` -- state graph definitions (agent, tool, user states)

--- a/agent_module/agent.py
+++ b/agent_module/agent.py
@@ -246,7 +246,7 @@ class Agent:
             print(f"[TIMING] state.run: {time.time() - t0:.3f}s")
             print(f"[TIMING] loop total: {time.time() - loop_start:.3f}s")
             if update:
-                assert isinstance(update,StateOutput), "State's output was not instance StateOutput"
+                assert isinstance(update, StateOutput), "State's output was not instance StateOutput"
                 if isinstance(update, StateOutput):
                     self.last_state_output = update
                     context_message = AIMessage(content=update.content)
@@ -320,7 +320,7 @@ class Agent:
 
             # Stream the state's output character by character
             if update and hasattr(update, "content") and update.content:
-                assert isinstance(update,StateOutput), "State's output was not instance StateOutput"
+                assert isinstance(update, StateOutput), "State's output was not instance StateOutput"
                 if isinstance(update, StateOutput):
                     self.last_state_output = update
                     context_message = AIMessage(content=update.content)

--- a/agent_module/agent.py
+++ b/agent_module/agent.py
@@ -14,6 +14,7 @@ from memory_module.memory import Memory
 
 # Assuming ArkModelLink.generate_response is actually ArkModelLink.agenerate_response
 from model_module.ArkModelNew import AIMessage, ArkModelLink, SystemMessage
+from state_module.base_state import StateOutput
 from state_module.state_handler import StateHandler
 
 MAX_ITER = 10
@@ -44,6 +45,7 @@ class Agent:
         self.tool_names = []
         self.available_tools = {}
         self.current_user_id = None  # Set per-request for per-user tool auth
+        self.last_state_output: StateOutput | None = None
 
     # def bind_tool(self, tool):
     #
@@ -221,7 +223,7 @@ class Agent:
 
         print("agent.py received message")
 
-        last_ai_message = None
+        self.last_state_output = None
         retry_count = 0
         print("agent.py CURR STATE: ", self.current_state)
         print("agent.py IS TERMINAL?:", self.current_state.is_terminal)
@@ -244,12 +246,11 @@ class Agent:
             print(f"[TIMING] state.run: {time.time() - t0:.3f}s")
             print(f"[TIMING] loop total: {time.time() - loop_start:.3f}s")
             if update:
-                # messages_list.append(update)
-                update_list = [update]
-                self.add_context(update_list)  # add update to memory
-
-                if isinstance(update, AIMessage):
-                    last_ai_message = update
+                assert isinstance(update,StateOutput), "State's output was not instance StateOutput"
+                if isinstance(update, StateOutput):
+                    self.last_state_output = update
+                    context_message = AIMessage(content=update.content)
+                self.add_context([context_message])
 
             if self.current_state.is_terminal:
                 print("REACHED TERMINAL")
@@ -273,9 +274,9 @@ class Agent:
                 break  # No transition ready, exit gracefully
 
         print(f"[TIMING] step total: {time.time() - step_start:.3f}s")
-        print("LAST_AI_MSG", last_ai_message)
+        print("LAST_STATE_OUTPUT", self.last_state_output)
         self.current_state = self.flow.get_state("agent_reply")
-        return last_ai_message
+        return self.last_state_output
 
     async def step_stream(self, messages, user_id: str = None):
         """
@@ -310,20 +311,31 @@ class Agent:
                 print(f"agent.py [STREAM] State returned: {type(update).__name__}")
             except Exception as e:
                 print(f"agent.py [STREAM] State error: {e}")
-                update = AIMessage(content=f"Error: {str(e)[:200]}")
+                update = StateOutput(
+                    content=f"Error: {str(e)[:200]}",
+                    completion_signal="error",
+                    error_detail=str(e),
+                )
                 self.current_state = self.flow.get_state("agent_reply")
 
             # Stream the state's output character by character
             if update and hasattr(update, "content") and update.content:
-                self.add_context([update])
+                assert isinstance(update,StateOutput), "State's output was not instance StateOutput"
+                if isinstance(update, StateOutput):
+                    self.last_state_output = update
+                    context_message = AIMessage(content=update.content)
+                self.add_context([context_message])
+
+            if update and hasattr(update, "content") and update.content:
+                if isinstance(update, StateOutput):
+                    self.last_state_output = update
+                    context_message = AIMessage(content=update.content)
+                self.add_context([context_message])
                 print(f"agent.py [STREAM] Streaming {len(update.content)} chars")
 
                 # Stream character by character for smooth output
                 for char in update.content:
                     yield char
-
-                if isinstance(update, AIMessage):
-                    print("agent.py [STREAM] AIMessage streamed")
 
             # Check terminal
             if self.current_state.is_terminal:

--- a/agent_module/agent.py
+++ b/agent_module/agent.py
@@ -247,10 +247,9 @@ class Agent:
             print(f"[TIMING] loop total: {time.time() - loop_start:.3f}s")
             if update:
                 assert isinstance(update, StateOutput), "State's output was not instance StateOutput"
-                if isinstance(update, StateOutput):
-                    self.last_state_output = update
-                    context_message = AIMessage(content=update.content)
-                self.add_context([context_message])
+                self.last_state_output = update
+                if update.content:
+                    self.add_context([AIMessage(content=update.content)])
 
             if self.current_state.is_terminal:
                 print("REACHED TERMINAL")
@@ -318,24 +317,14 @@ class Agent:
                 )
                 self.current_state = self.flow.get_state("agent_reply")
 
-            # Stream the state's output character by character
-            if update and hasattr(update, "content") and update.content:
+            if update:
                 assert isinstance(update, StateOutput), "State's output was not instance StateOutput"
-                if isinstance(update, StateOutput):
-                    self.last_state_output = update
-                    context_message = AIMessage(content=update.content)
-                self.add_context([context_message])
-
-            if update and hasattr(update, "content") and update.content:
-                if isinstance(update, StateOutput):
-                    self.last_state_output = update
-                    context_message = AIMessage(content=update.content)
-                self.add_context([context_message])
-                print(f"agent.py [STREAM] Streaming {len(update.content)} chars")
-
-                # Stream character by character for smooth output
-                for char in update.content:
-                    yield char
+                self.last_state_output = update
+                if update.content:
+                    self.add_context([AIMessage(content=update.content)])
+                    print(f"agent.py [STREAM] Streaming {len(update.content)} chars")
+                    for char in update.content:
+                        yield char
 
             # Check terminal
             if self.current_state.is_terminal:

--- a/agent_module/agent.py
+++ b/agent_module/agent.py
@@ -228,7 +228,7 @@ class Agent:
         print("agent.py CURR STATE: ", self.current_state)
         print("agent.py IS TERMINAL?:", self.current_state.is_terminal)
 
-        while not self.current_state.is_terminal:
+        while True:
             loop_start = time.time()
             print(f"Inner loop #{retry_count + 1}")
 
@@ -294,7 +294,7 @@ class Agent:
 
         retry_count = 0
 
-        while not self.current_state.is_terminal:
+        while True:
             print(f"agent.py [STREAM] Inner loop - State: {self.current_state.name}")
 
             if retry_count > MAX_ITER:

--- a/db/migrate.py
+++ b/db/migrate.py
@@ -8,8 +8,9 @@ Reads connection from DB_URL env var or constructs from POSTGRES_PASSWORD.
 
 import os
 import sys
-import psycopg2
 from pathlib import Path
+
+import psycopg2
 
 
 def get_connection_url():
@@ -45,7 +46,7 @@ def table_exists(conn, table_name):
 
 def run_migration(conn, migration_path):
     """Read and execute a migration SQL file."""
-    with open(migration_path, 'r') as f:
+    with open(migration_path) as f:
         sql = f.read()
 
     with conn.cursor() as cur:

--- a/db/migrate.py
+++ b/db/migrate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Migration runner for Arkos database schema.
+
+Applies pending migrations from db/migrations/ if the tasks table doesn't exist.
+Reads connection from DB_URL env var or constructs from POSTGRES_PASSWORD.
+"""
+
+import os
+import sys
+import psycopg2
+from pathlib import Path
+
+
+def get_connection_url():
+    """Get Postgres connection URL from env or construct from POSTGRES_PASSWORD."""
+    db_url = os.environ.get("DB_URL")
+    if db_url:
+        return db_url
+
+    # Construct from POSTGRES_PASSWORD and defaults (matching docker-compose.yml)
+    password = os.environ.get("POSTGRES_PASSWORD", "postgres")
+    host = os.environ.get("POSTGRES_HOST", "localhost")
+    port = os.environ.get("POSTGRES_PORT", "5432")
+    dbname = os.environ.get("POSTGRES_DB", "postgres")
+    user = os.environ.get("POSTGRES_USER", "postgres")
+
+    return f"postgresql://{user}:{password}@{host}:{port}/{dbname}"
+
+
+def table_exists(conn, table_name):
+    """Check if a table exists in the database."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_name = %s AND table_schema = 'public'
+            )
+            """,
+            (table_name,)
+        )
+        return cur.fetchone()[0]
+
+
+def run_migration(conn, migration_path):
+    """Read and execute a migration SQL file."""
+    with open(migration_path, 'r') as f:
+        sql = f.read()
+
+    with conn.cursor() as cur:
+        cur.execute(sql)
+
+    conn.commit()
+
+
+def main():
+    """Main migration runner logic."""
+    try:
+        db_url = get_connection_url()
+        conn = psycopg2.connect(db_url)
+
+        # Check if tasks table already exists
+        if table_exists(conn, "tasks"):
+            print("✓ tasks table already exists. No migration needed.")
+            conn.close()
+            return 0
+
+        # Table doesn't exist, apply migration
+        migration_file = Path(__file__).parent / "migrations" / "0001_create_tasks_table.sql"
+
+        if not migration_file.exists():
+            print(f"✗ Migration file not found: {migration_file}", file=sys.stderr)
+            conn.close()
+            return 1
+
+        print(f"Running migration: {migration_file.name}")
+        run_migration(conn, migration_file)
+
+        if table_exists(conn, "tasks"):
+            print("✓ tasks table created successfully.")
+            conn.close()
+            return 0
+        else:
+            print("✗ Migration ran but tasks table was not created.", file=sys.stderr)
+            conn.close()
+            return 1
+
+    except Exception as e:
+        print(f"✗ Migration failed: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/memory_module/memory.py
+++ b/memory_module/memory.py
@@ -157,7 +157,7 @@ class Memory:
                 self._pool.putconn(conn)
 
             # Store in mem0 in background (non-blocking)
-            if self.use_long_term and self._mem0:
+            if self.use_long_term and self._mem0 and message.content:
                 metadata = {
                     "user_id": self.user_id,
                     "session_id": self.session_id,

--- a/state_module/base_state.py
+++ b/state_module/base_state.py
@@ -1,0 +1,20 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class StateOutput(BaseModel):
+    """Structured return type for all state run() methods."""
+
+    content: str = Field(description="The text content produced by the state.")
+    completion_signal: Literal["complete", "incomplete", "error", "needs_input"] = Field(
+        description="Indicates the outcome of the state's execution."
+    )
+    structured_data: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional structured payload produced by the state.",
+    )
+    error_detail: str | None = Field(
+        default=None,
+        description="Error message when completion_signal is 'error'.",
+    )

--- a/state_module/state_ai.py
+++ b/state_module/state_ai.py
@@ -3,11 +3,12 @@ import sys
 
 from pydantic import BaseModel, Field
 
-from model_module.ArkModelNew import AIMessage, SystemMessage
+from model_module.ArkModelNew import SystemMessage
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
+from state_module.base_state import StateOutput
 from state_module.state import State
 from state_module.state_registry import register_state
 
@@ -72,14 +73,20 @@ class StateAI(State):
 
         # Handle None or empty content
         if not output or not output.content:
-            return AIMessage(content="I encountered an issue processing your request. Please try again.")
+            return StateOutput(
+                content="I encountered an issue processing your request. Please try again.",
+                completion_signal="error",
+                error_detail="LLM returned empty content",
+            )
 
         try:
             data = ReasonedOutput.model_validate_json(output.content)
         except Exception as e:
-            # If JSON parsing fails, return the raw content as fallback
             print(f"Failed to parse structured output: {e}")
-            return AIMessage(content=output.content)
+            return StateOutput(
+                content=output.content,
+                completion_signal="complete",
+            )
 
         # Build response including the approach/reasoning
         response_parts = []
@@ -101,4 +108,5 @@ class StateAI(State):
             response_parts.append(data.clarifying_question)
 
         response = "\n".join(response_parts) if response_parts else data.final
-        return AIMessage(content=response)
+        signal = "needs_input" if data.needs_clarification else "complete"
+        return StateOutput(content=response, completion_signal=signal)

--- a/state_module/state_tool.py
+++ b/state_module/state_tool.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 from model_module.ArkModelNew import SystemMessage
+from state_module.base_state import StateOutput
 from state_module.state import State
 from state_module.state_registry import register_state
 from tool_module.tool_call import AuthRequiredError
@@ -86,12 +87,18 @@ class StateTool(State):
         try:
             tool_arg_dict = await self.choose_tool(context=context, agent=agent)
             tool_result = await self.execute_tool(tool_call=tool_arg_dict, agent=agent)
-            return SystemMessage(content=str(tool_result))
+            return StateOutput(
+                content=str(tool_result),
+                completion_signal="complete",
+                structured_data={"tool_result": tool_result},
+            )
 
         except AuthRequiredError as e:
-            # Return friendly message with connect link
-            return SystemMessage(
-                content=f"To complete this request, please connect your {e.service_info.get('name', e.service)}:\n\n"
-                f"👉 {e.connect_url}\n\n"
-                f"After connecting, try your request again."
+            return StateOutput(
+                content=(
+                    f"To complete this request, please connect your {e.service_info.get('name', e.service)}:\n\n"
+                    f"👉 {e.connect_url}\n\n"
+                    f"After connecting, try your request again."
+                ),
+                completion_signal="needs_input",
             )

--- a/state_module/state_user.py
+++ b/state_module/state_user.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+from state_module.base_state import StateOutput
 from state_module.state import State
 from state_module.state_registry import register_state
 
@@ -21,6 +22,9 @@ class StateUser(State):
         """Always ready to transition once user provides input."""
         return True
 
-    def run(self, context):
-        """No-op; the user state simply passes control back."""
-        return None
+    async def run(self, context, agent=None):
+        """Signals that control is being returned to the user."""
+        return StateOutput(
+            content="",
+            completion_signal="needs_input",
+        )

--- a/tests/test_state_module.py
+++ b/tests/test_state_module.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 
 from model_module.ArkModelNew import AIMessage, SystemMessage
+from state_module.base_state import StateOutput
 from state_module.state import State
 from state_module.state_ai import ReasonedOutput, StateAI
 from state_module.state_registry import STATE_REGISTRY, register_state
@@ -129,7 +130,7 @@ class TestStateAI:
             mock_agent,
         )
 
-        assert isinstance(result, AIMessage)
+        assert isinstance(result, StateOutput)
         assert "Here is your answer." in result.content
         assert "step 1" in result.content
 
@@ -140,7 +141,7 @@ class TestStateAI:
         mock_agent.call_llm = AsyncMock(return_value=AIMessage(content="not valid json at all"))
 
         result = await sa.run([], mock_agent)
-        assert isinstance(result, AIMessage)
+        assert isinstance(result, StateOutput)
         assert result.content == "not valid json at all"
 
     @pytest.mark.asyncio
@@ -150,7 +151,7 @@ class TestStateAI:
         mock_agent.call_llm = AsyncMock(return_value=AIMessage(content=None))
 
         result = await sa.run([], mock_agent)
-        assert isinstance(result, AIMessage)
+        assert isinstance(result, StateOutput)
         assert "issue" in result.content.lower() or "try again" in result.content.lower()
 
     @pytest.mark.asyncio
@@ -255,7 +256,7 @@ class TestStateTool:
             mock_exec.return_value = "42"
 
             result = await st.run([], mock_agent)
-            assert isinstance(result, SystemMessage)
+            assert isinstance(result, StateOutput)
             assert "42" in result.content
 
 

--- a/tests/test_state_module.py
+++ b/tests/test_state_module.py
@@ -56,10 +56,14 @@ class TestStateUser:
         su = StateUser("u", {})
         assert su.check_transition_ready({}) is True
         assert su.check_transition_ready({"anything": "here"}) is True
-
-    def test_run_returns_none(self):
+    
+    @pytest.mark.asyncio
+    async def test_run_returns_none(self):
         su = StateUser("u", {})
-        assert su.run({}) is None
+        result = await su.run({})
+        assert result is not None
+        assert result.completion_signal == "needs_input"
+        assert result.content == ""
 
 
 # --- ReasonedOutput ---

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -156,8 +156,7 @@ class TestStdioTransport:
         mock_proc.wait = AsyncMock()
         t.process = mock_proc
 
-        with patch("asyncio.wait_for", new_callable=AsyncMock):
-            await t.close()
+        await t.close()
         assert t.process is None
 
 

--- a/tool_module/tool_call.py
+++ b/tool_module/tool_call.py
@@ -129,7 +129,7 @@ class MCPClient:
         except Exception as e:
             logger.error(f"Failed to start MCP server '{self.config.name}': {e}")
             await self.stop()
-            raise
+            raise RuntimeError(f"Failed to start MCP server '{self.config.name}': {e}") from e
 
     async def stop(self) -> None:
         """Stop the MCP server connection gracefully."""


### PR DESCRIPTION
## What changed
Add Postgres migration system and create `tasks` table for persisting, tracking, and ordering agent tasks.

## Why
Current system has no persistence — API calls create ephemeral agents with no status tracking or ordering. This migration adds the schema foundation for a task queue: task_id (UUID), user_id, status (enum: pending/running/completed/failed/cancelled), required_tools (TEXT[]), context_payload (JSONB), created_at, updated_at. Also includes Python runner (`db/migrate.py`) that idempotently applies migrations.

## Type
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `test` — tests only
- [ ] `chore` — deps, config, CI, tooling
- [ ] `docs` — documentation only

## How to test
```bash
# Set connection (either via env var or password)
DB_URL="postgresql://..." python db/migrate.py
# or
POSTGRES_PASSWORD=your_password python db/migrate.py

# Verify schema was created
psql "postgresql://..." -c "\d tasks"

# Run it again — should say table already exists (idempotent)
python db/migrate.py