### PR TITLE
Vin/tasks api

### DIFF
--- a/base_module/app.py
+++ b/base_module/app.py
@@ -13,6 +13,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from agent_module.agent import Agent
 from base_module.auth import router as auth_router
+from base_module.tasks import router as tasks_router
 from config_module.loader import config
 from memory_module.memory import Memory
 from model_module.ArkModelNew import AIMessage, ArkModelLink, SystemMessage, UserMessage
@@ -22,6 +23,7 @@ from tool_module.tool_call import MCPToolManager
 
 app = FastAPI(title="ArkOS Agent API", version="1.0.0")
 app.include_router(auth_router)
+app.include_router(tasks_router)
 
 
 # Initialize the agent and dependencies once

--- a/base_module/tasks.py
+++ b/base_module/tasks.py
@@ -1,0 +1,125 @@
+"""
+Task queue API router for submitting, querying, and updating tasks.
+Stubs for persistence; schema defined in db/migrations/0001_create_tasks_table.sql
+"""
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+class TaskStatus(str, Enum):
+    """Task status values matching db schema."""
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class TaskRequest(BaseModel):
+    """Request model for creating a task."""
+    user_id: str
+    required_tools: Optional[List[str]] = None
+    context_payload: Optional[dict] = None
+
+
+class TaskResponse(BaseModel):
+    """Response model for a task."""
+    task_id: str
+    user_id: str
+    status: TaskStatus
+    required_tools: List[str]
+    context_payload: dict
+    created_at: datetime
+    updated_at: datetime
+
+
+class TaskListResponse(BaseModel):
+    """Response model for task list with metadata."""
+    tasks: List[TaskResponse]
+    total: int
+
+
+class StatusUpdateRequest(BaseModel):
+    """Request model for updating task status."""
+    status: TaskStatus
+
+
+# In-memory store for stubs (will be replaced by DB calls)
+_tasks_store: dict[str, dict] = {}
+
+
+@router.post("")
+async def create_task(task_req: TaskRequest) -> TaskResponse:
+    """
+    POST /tasks
+    Submit a new task to the queue.
+
+    Returns: 200 with task_id and full task object
+    """
+    task_id = str(uuid.uuid4())
+    now = datetime.utcnow()
+
+    task = {
+        "task_id": task_id,
+        "user_id": task_req.user_id,
+        "status": TaskStatus.PENDING,
+        "required_tools": task_req.required_tools or [],
+        "context_payload": task_req.context_payload or {},
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    # Store in-memory stub
+    _tasks_store[task_id] = task
+
+    return TaskResponse(**task)
+
+
+@router.get("")
+async def list_tasks(user_id: str = Query(...)) -> TaskListResponse:
+    """
+    GET /tasks?user_id=<user_id>
+    Query tasks for a specific user.
+
+    Returns: 200 with list of tasks and total count
+    """
+    user_tasks = [
+        TaskResponse(**task)
+        for task in _tasks_store.values()
+        if task["user_id"] == user_id
+    ]
+
+    return TaskListResponse(
+        tasks=user_tasks,
+        total=len(user_tasks),
+    )
+
+
+@router.patch("/{task_id}/status")
+async def update_task_status(
+    task_id: str,
+    status_req: StatusUpdateRequest,
+) -> TaskResponse:
+    """
+    PATCH /tasks/{task_id}/status
+    Update the status of an existing task.
+
+    Returns: 200 with updated task object
+    Raises: 404 if task not found
+    """
+    if task_id not in _tasks_store:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+
+    task = _tasks_store[task_id]
+    task["status"] = status_req.status
+    task["updated_at"] = datetime.utcnow()
+
+    return TaskResponse(**task)

--- a/base_module/tasks.py
+++ b/base_module/tasks.py
@@ -5,8 +5,7 @@ Stubs for persistence; schema defined in db/migrations/0001_create_tasks_table.s
 
 import uuid
 from datetime import datetime
-from enum import Enum
-from typing import List, Optional
+from enum import StrEnum
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
@@ -14,7 +13,7 @@ from pydantic import BaseModel
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 
-class TaskStatus(str, Enum):
+class TaskStatus(StrEnum):
     """Task status values matching db schema."""
     PENDING = "pending"
     RUNNING = "running"
@@ -26,8 +25,8 @@ class TaskStatus(str, Enum):
 class TaskRequest(BaseModel):
     """Request model for creating a task."""
     user_id: str
-    required_tools: Optional[List[str]] = None
-    context_payload: Optional[dict] = None
+    required_tools: list[str] | None = None
+    context_payload: dict | None = None
 
 
 class TaskResponse(BaseModel):
@@ -35,7 +34,7 @@ class TaskResponse(BaseModel):
     task_id: str
     user_id: str
     status: TaskStatus
-    required_tools: List[str]
+    required_tools: list[str]
     context_payload: dict
     created_at: datetime
     updated_at: datetime
@@ -43,7 +42,7 @@ class TaskResponse(BaseModel):
 
 class TaskListResponse(BaseModel):
     """Response model for task list with metadata."""
-    tasks: List[TaskResponse]
+    tasks: list[TaskResponse]
     total: int
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,10 +1,10 @@
 """Tests for task queue API endpoints (base_module/tasks.py)."""
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from base_module.tasks import router, TaskStatus, _tasks_store
-from fastapi import FastAPI
+from base_module.tasks import _tasks_store, router
 
 
 @pytest.fixture

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,162 @@
+"""Tests for task queue API endpoints (base_module/tasks.py)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from base_module.tasks import router, TaskStatus, _tasks_store
+from fastapi import FastAPI
+
+
+@pytest.fixture
+def client():
+    """Create test client with tasks router."""
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_tasks():
+    """Clear in-memory task store before each test."""
+    _tasks_store.clear()
+    yield
+    _tasks_store.clear()
+
+
+class TestCreateTask:
+    def test_post_returns_200_with_task_id(self, client):
+        """POST /tasks returns 200 with task_id"""
+        payload = {
+            "user_id": "test-user",
+            "required_tools": ["tool1", "tool2"],
+            "context_payload": {"key": "value"}
+        }
+        response = client.post("/tasks", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "task_id" in data
+        assert data["user_id"] == "test-user"
+        assert data["status"] == "pending"
+        assert data["required_tools"] == ["tool1", "tool2"]
+        assert data["context_payload"] == {"key": "value"}
+
+    def test_post_minimal_payload(self, client):
+        """POST /tasks with minimal payload"""
+        payload = {"user_id": "user123"}
+        response = client.post("/tasks", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["required_tools"] == []
+        assert data["context_payload"] == {}
+
+
+class TestListTasks:
+    def test_get_returns_list(self, client):
+        """GET /tasks?user_id= returns list"""
+        # Create a task first
+        client.post("/tasks", json={"user_id": "user-a"})
+        client.post("/tasks", json={"user_id": "user-a"})
+        client.post("/tasks", json={"user_id": "user-b"})
+
+        # List tasks for user-a
+        response = client.get("/tasks?user_id=user-a")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "tasks" in data
+        assert "total" in data
+        assert data["total"] == 2
+        assert len(data["tasks"]) == 2
+        assert all(t["user_id"] == "user-a" for t in data["tasks"])
+
+    def test_get_empty_list(self, client):
+        """GET /tasks returns empty list for user with no tasks"""
+        response = client.get("/tasks?user_id=nonexistent")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 0
+        assert data["tasks"] == []
+
+    def test_get_requires_user_id(self, client):
+        """GET /tasks without user_id param returns 422"""
+        response = client.get("/tasks")
+        assert response.status_code == 422
+
+
+class TestUpdateTaskStatus:
+    def test_patch_updates_status(self, client):
+        """PATCH /tasks/{id}/status updates status"""
+        # Create a task
+        create_resp = client.post("/tasks", json={"user_id": "user1"})
+        task_id = create_resp.json()["task_id"]
+
+        # Update status
+        payload = {"status": "running"}
+        response = client.patch(f"/tasks/{task_id}/status", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "running"
+        assert data["task_id"] == task_id
+
+    def test_patch_multiple_status_transitions(self, client):
+        """PATCH can update status multiple times"""
+        create_resp = client.post("/tasks", json={"user_id": "user1"})
+        task_id = create_resp.json()["task_id"]
+
+        # pending -> running
+        client.patch(f"/tasks/{task_id}/status", json={"status": "running"})
+
+        # running -> completed
+        response = client.patch(f"/tasks/{task_id}/status", json={"status": "completed"})
+        assert response.json()["status"] == "completed"
+
+    def test_patch_nonexistent_task_returns_404(self, client):
+        """PATCH nonexistent task returns 404"""
+        payload = {"status": "completed"}
+        response = client.patch("/tasks/nonexistent-id/status", json=payload)
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"]
+
+    def test_patch_accepts_all_statuses(self, client):
+        """PATCH accepts all valid TaskStatus values"""
+        create_resp = client.post("/tasks", json={"user_id": "user1"})
+        task_id = create_resp.json()["task_id"]
+
+        for status in ["pending", "running", "completed", "failed", "cancelled"]:
+            response = client.patch(
+                f"/tasks/{task_id}/status",
+                json={"status": status}
+            )
+            assert response.status_code == 200
+            assert response.json()["status"] == status
+
+
+class TestTaskTimestamps:
+    def test_created_at_set_on_creation(self, client):
+        """Task has created_at when created"""
+        response = client.post("/tasks", json={"user_id": "user1"})
+        task = response.json()
+        assert "created_at" in task
+        assert task["created_at"] is not None
+
+    def test_updated_at_changes_on_status_update(self, client):
+        """Task updated_at changes when updated"""
+        create_resp = client.post("/tasks", json={"user_id": "user1"})
+        task_id = create_resp.json()["task_id"]
+        created_at = create_resp.json()["created_at"]
+
+        # Update status
+        import time
+        time.sleep(0.1)  # Ensure time difference
+        update_resp = client.patch(
+            f"/tasks/{task_id}/status",
+            json={"status": "running"}
+        )
+        updated_at = update_resp.json()["updated_at"]
+
+        assert updated_at != created_at


### PR DESCRIPTION
## What changed
Stub POST/GET/PATCH task queue endpoints in FastAPI with in-memory storage.

## Why
Frontend and agent need working endpoints to test queue integration before database persistence is implemented. Unblocks task submission and status tracking UX work.

## Type
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `test` — tests only
- [ ] `chore` — deps, config, CI, tooling
- [ ] `docs` — documentation only

## How to test
```bash
# Run task endpoint tests
pytest tests/test_tasks.py -v

# Manual curl tests
curl -X POST http://localhost:1112/tasks \
  -H "Content-Type: application/json" \
  -d '{"user_id":"test-user"}'

curl "http://localhost:1112/tasks?user_id=test-user"