### PR TITLE
chore: pause deploy infra until product is ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,37 +81,27 @@ jobs:
         run: pytest tests/ -v --cov=. --cov-report=term-missing -m "not integration"
 
   # ──────────────────────────────────────────────
-  # Stage 3: Build and push Docker image to GHCR
-  # Only pushes on main branch; PRs just build to verify.
+  # Stage 3: Build the Docker image to verify the Dockerfile still works.
+  # Image is NOT pushed anywhere — there's no production deployment yet, so
+  # publishing to a registry would just be noise. Restore the GHCR push
+  # step (see git history for this file at the previous revision) when
+  # there's a product worth deploying.
   # ──────────────────────────────────────────────
   build:
-    name: Build & Push Docker Image
+    name: Build Docker Image
     runs-on: ubuntu-latest
     needs: [lint, test]
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GitHub Container Registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image
+      - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
-            ghcr.io/${{ github.repository }}:latest
+          push: false
+          tags: arkos:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/deploy.yml.disabled
+++ b/.github/workflows/deploy.yml.disabled
@@ -1,14 +1,26 @@
 name: Deploy
 
-# Deploys the ArkOS app as a Docker container on ark.mit.edu.
-# Uses the kshitij user (who has docker group access) — no sudo needed.
+# DISABLED. Renamed from deploy.yml to deploy.yml.disabled because GitHub
+# Actions only schedules files matching .github/workflows/*.yml.
+# To re-enable: `git mv deploy.yml.disabled deploy.yml` and re-publish the
+# image to GHCR (also disabled in ci.yml — see that file's git history).
 #
-# BEFORE THIS WORKS, you need to configure:
-#   1. GitHub repo secret: SSH_PRIVATE_KEY (private key for kshitij@ark.mit.edu)
-#   2. On ark.mit.edu: the corresponding public key in ~/.ssh/authorized_keys
-#   3. On ark.mit.edu: /home/kshitij/arkos/.env file with DB_URL, OPENAI_API_KEY, etc.
-#   4. Either: make the ghcr.io/sgiark/arkos package public
-#      OR: run `docker login ghcr.io` once on ark.mit.edu as kshitij
+# Why disabled: there's no production product to deploy yet. The MCP/agent
+# stack works in dev but isn't in a "ship it on every main push" state.
+# Keeping the workflow file in tree (not deleting) so we don't have to
+# re-derive the deploy plumbing from scratch when we're ready.
+#
+# BEFORE THIS WORKS, you also need to configure:
+#   1. Switch DEPLOY_USER from kshitij to arkos (the service account
+#      nmorgan provisioned post-merge of PR #190 follow-ups).
+#   2. GitHub repo secret: SSH_PRIVATE_KEY (private key for arkos@ark.mit.edu)
+#   3. On ark.mit.edu: the corresponding public key in ~/.ssh/authorized_keys
+#      for the arkos user.
+#   4. On ark.mit.edu: /home/arkos/arkos/.env file with DB_URL,
+#      OPENAI_API_KEY, SMITHERY_API_KEY, etc.
+#   5. Either: make the ghcr.io/sgiark/arkos package public
+#      OR: run `docker login ghcr.io` once on ark.mit.edu as arkos.
+#   6. Verify the server's root disk has space (was 99% full last check).
 
 on:
   push:

--- a/.github/workflows/monitor.yml.disabled
+++ b/.github/workflows/monitor.yml.disabled
@@ -1,11 +1,16 @@
 name: Monitor
 
-# Pings the production server every 30 minutes.
-# GitHub sends an email notification if the workflow fails.
+# DISABLED. Renamed from monitor.yml to monitor.yml.disabled because
+# GitHub Actions only schedules files matching .github/workflows/*.yml.
+# To re-enable: `git mv monitor.yml.disabled monitor.yml`.
+#
+# Why disabled: there's nothing live to monitor. The deploy workflow is
+# also disabled, so the production /health endpoint this would ping
+# doesn't exist yet.
 #
 # BEFORE THIS WORKS, you need to configure:
-#   1. GitHub repo secret: MONITOR_URL (e.g. https://ark.mit.edu:1112)
-#      OR update the URL below to match your deployment.
+#   1. GitHub repo secret: MONITOR_URL (e.g. http://ark.mit.edu:1112)
+#      OR update the URL below to match the eventual deployment.
 
 on:
   schedule:


### PR DESCRIPTION
> **Stacked on top of #200.** Set the base back to \`main\` once #200 merges.

## What changed

| File | Change |
|------|--------|
| \`.github/workflows/ci.yml\` | Drop the GHCR login + push step. Build still runs to verify the Dockerfile, but the image isn't published. |
| \`.github/workflows/deploy.yml\` → \`.yml.disabled\` | Renamed so GitHub Actions stops scheduling it. Header updated with re-enable instructions. |
| \`.github/workflows/monitor.yml\` → \`.yml.disabled\` | Same treatment. |

Net diff: 3 files changed, 38 insertions, 31 deletions.

## Why

There's no production product to ship yet. The deploy + monitor + GHCR-push plumbing was built against the assumption we'd start auto-deploying to \`ark.mit.edu\` immediately, but per nmorgan we're holding off until there's something worth shipping. Until then:

- Pushing a Docker image to GHCR on every main push fills the org's package storage with images that nothing pulls.
- The deploy workflow tries to SSH into a server with a missing SSH key secret + nonexistent target user, so it fails noisily on every main push.
- The monitor workflow pings a URL that doesn't return anything useful (no live deployment).

Pausing all three keeps CI signal clean (lint + test + Dockerfile-build verification still run on every PR) without the noise.

## Why rename instead of delete

Renaming to \`.yml.disabled\` (vs. deleting outright) means we don't lose the SSH plumbing, smoke test, rollback logic, and per-service health-check config we wrote. When there's a product to deploy:

\`\`\`bash
git mv .github/workflows/deploy.yml.disabled .github/workflows/deploy.yml
git mv .github/workflows/monitor.yml.disabled .github/workflows/monitor.yml
\`\`\`

…then add the GHCR push step back in ci.yml (visible in this file's git history), set \`DEPLOY_USER=arkos\`, add \`SSH_PRIVATE_KEY\` + \`MONITOR_URL\` secrets, verify disk space on the server, and you're shipping again.

## Type

- [ ] \`feat\` — new capability
- [ ] \`fix\` — bug fix
- [ ] \`refactor\` — restructure without behavior change
- [ ] \`test\` — tests only
- [x] \`chore\` — deps, config, CI, tooling
- [ ] \`docs\` — documentation only

## How to test

After merge:

1. Open any PR. Confirm the **CI** workflow runs with three jobs: \`Lint & Format\`, \`Tests\`, \`Build Docker Image\` — no GHCR login step, no \`Deploy\` workflow listed.
2. Push to main. Confirm only the **CI** workflow runs (no Deploy, no Monitor).
3. Visit Actions → confirm \`Deploy\` and \`Monitor\` are no longer in the workflows sidebar (\`.disabled\` files don't register).

Locally:

\`\`\`bash
ruff check . && ruff format --check .
pytest tests/ -m "not integration"
\`\`\`

Both should pass clean (this PR doesn't touch source code).

## Checklist

- [x] \`ruff check .\` passes
- [x] \`ruff format --check .\` passes
- [ ] \`mypy .\` passes — same caveat as #200 (no mypy baseline)
- [x] \`pytest tests/ -v -m "not integration"\` passes (237/237)
- [x] Type annotations on all new functions (no new functions added)
- [x] No unrelated changes in this PR
- [x] New behavior has a test (no new behavior; behavior was paused)

## Out of scope (revisit when there's a product)

- \`SSH_PRIVATE_KEY\` GitHub secret
- \`MONITOR_URL\` GitHub secret
- Switching \`DEPLOY_USER\` from \`kshitij\` to \`arkos\` (the service account nmorgan provisioned)
- Resource limits (\`--memory\`, \`--cpus\`, \`--log-opt max-size\`) on the deploy container
- Cleaning up the 99%-full root disk on \`ark.mit.edu\`
- Making \`ghcr.io/sgiark/arkos\` package public
- Migrating off \`--network host\` to published ports + \`host.docker.internal\`

All of these are necessary for a working production deploy. None of them matter while there isn't one.