### PR TITLE
Add browserless service to docker-compose (browser automation Task 1)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,17 @@ services:
       - arkos-network
 
   # ============================================
+  # Browserless - Sandboxed Chromium pool (CDP over WebSocket)
+  # ============================================
+  browserless:
+    image: ghcr.io/browserless/chromium:latest
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    networks:
+      - arkos-network
+
+  # ============================================
   # Supabase Services
   # ============================================
   supabase-db:


### PR DESCRIPTION
## What changed
Adds a `browserless` service to `docker-compose.yml` so other services can connect to a sandboxed Chromium pool over CDP at `ws://browserless:3000`.

## Why
Task 1 of the multi-user sandboxed browser automation feature spec. This is the foundation that the upcoming `browser_tool.py` will connect to.

## Type
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `test` — tests only
- [x] `chore` — deps, config, CI, tooling
- [ ] `docs` — documentation only

## How to test
Bring up just the new service and verify the WebSocket handshake plus a real page load. End-to-end CDP test was also run on `ark.mit.edu` over an SSH tunnel and the title came back as expected.

```bash
docker compose up -d browserless

# spec acceptance test: handshake returns 101
curl --include --max-time 3 \
  -H "Connection: Upgrade" -H "Upgrade: websocket" \
  -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
  -H "Sec-WebSocket-Version: 13" \
  http://localhost:3000

# real browser drive
curl -s -X POST http://localhost:3000/content \
  -H "Content-Type: application/json" \
  -d '{"url":"https://example.com"}' | grep -oE "<title>[^<]+</title>"
# expect: <title>Example Domain</title>
```

## Checklist
- [x] `ruff check .` passes (no Python changes)
- [x] `ruff format --check .` passes (no Python changes)
- [x] `mypy .` passes (no Python changes)
- [x] `pytest tests/ -v -m "not integration"` passes (no test-affecting changes)
- [x] Type annotations on all new functions (n/a)
- [x] No unrelated changes in this PR
- [x] New behavior has a test (manual acceptance test from the spec, run locally and on ark.mit.edu)

## Notes
Concurrency limits, idle timeout, and auth token were intentionally left out of this PR. Those belong to Task 4 of the spec and will land separately so this diff stays small.

cc @n-morgan for review when you have a minute.