### PR TITLE
fix(MIT-229): remove hard character truncation of tool results in StateTool

### DIFF
--- a/state_module/state_tool.py
+++ b/state_module/state_tool.py
@@ -120,7 +120,7 @@ class StateTool(State):
                 log_event(
                     task_id,
                     "tool_result",
-                    str(tool_result)[:2000],
+                    str(tool_result),
                     payload={"tool_name": tool_arg_dict["tool_name"]},
                 )
 
@@ -128,7 +128,7 @@ class StateTool(State):
                 # Inside the executor graph: advance past this plan step
                 agent.step_idx = getattr(agent, "step_idx", 0) + 1
                 return StateOutput(
-                    content=f"tool `{tool_arg_dict['tool_name']}` -> {str(tool_result)[:400]}",
+                    content=f"tool `{tool_arg_dict['tool_name']}` -> {tool_result}",
                     completion_signal="complete",
                     structured_data={"tool_result": tool_result, "next_state": forced_next},
                 )

--- a/tests/test_state_module.py
+++ b/tests/test_state_module.py
@@ -310,6 +310,25 @@ class TestStateTool:
             assert isinstance(result, StateOutput)
             assert "42" in result.content
 
+    @pytest.mark.asyncio
+    async def test_run_does_not_truncate_long_tool_result(self):
+        """Regression test for MIT-229: tool results must not be truncated."""
+        st = StateTool("t", {})
+        mock_agent = MagicMock()
+        mock_agent.current_user_id = "user1"
+        mock_agent.pending_tool = {"tool_name": "list_events", "tool_args": {}}
+        mock_agent.task_id = None
+
+        long_result = "event_data:" + ("x" * 5000)
+
+        with patch.object(st, "execute_tool", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = long_result
+
+            result = await st.run([], mock_agent)
+            assert isinstance(result, StateOutput)
+            assert result.content == f"tool `list_events` -> {long_result}"
+            assert result.structured_data["tool_result"] == long_result
+
 
 # --- state_registry ---
 


### PR DESCRIPTION
## Summary
- Removes `[:400]` slice on `StateOutput.content` in the executor path (line 131) — was cutting off tool results before they reached agent memory
- Removes `[:2000]` slice on `log_event` call (line 123) — was truncating logged tool results

GCal and Linear responses exceeding these limits were silently cut off mid-result, breaking Ghost transcript parsing.

## Test
- `grep "tool_result\]\[:" state_module/state_tool.py` returns zero results
- Regression unit test added: `test_run_does_not_truncate_long_tool_result` asserts a 5000-char result passes through uncut in both `content` and `structured_data`

Closes MIT-229