### PR TITLE
docs(MIT-228): document forced state transition override in agent.py

### DIFF
--- a/agent_module/agent.py
+++ b/agent_module/agent.py
@@ -265,9 +265,27 @@ class Agent:
                 transition_dict = self.flow.get_transitions(self.current_state, messages_list)
                 transition_names = transition_dict["tt"]
 
-                # Deterministic override: a state can force the next transition
-                # by putting "next_state" into StateOutput.structured_data. This is
-                # how executor-style graphs bypass LLM-guided transition choice.
+                # Forced transition override
+                #
+                # Any state can bypass LLM-guided transition choice by setting
+                # structured_data["next_state"] in its StateOutput. The agent
+                # checks this first and skips the LLM call if a valid override
+                # is present.
+                #
+                # WHY: the executor graph (executor → tool → approval →
+                # executor_done) is a fixed sequence — the next step is never
+                # context-dependent, so running the LLM to "decide" would add
+                # latency and non-determinism. States that know their successor
+                # declare it explicitly instead.
+                #
+                # INVARIANT: the forced state must be a declared transition in
+                # state_graph.yaml for the current state. If it isn't,
+                # `forced in transition_names` is False and the agent falls back
+                # to normal LLM-guided choice — it never blindly jumps.
+                #
+                # STATES THAT USE THIS: state_executor, state_tool,
+                # state_approval, state_plan, state_ai. See
+                # docs/adr/001-forced-state-transition.md for full rationale.
                 forced = None
                 if update and isinstance(update.structured_data, dict):
                     forced = update.structured_data.get("next_state")
@@ -351,6 +369,7 @@ class Agent:
                 transition_names = transition_dict["tt"]
                 print(f"agent.py [STREAM] Transitions: {transition_names}")
 
+                # Forced transition override — see step() above for full explanation.
                 forced = None
                 if update and isinstance(update.structured_data, dict):
                     forced = update.structured_data.get("next_state")

--- a/docs/adr/001-forced-state-transition.md
+++ b/docs/adr/001-forced-state-transition.md
@@ -1,0 +1,50 @@
+# ADR 001: Forced State Transition Override
+
+## Status
+Accepted
+
+## Context
+
+The agent loop in `agent_module/agent.py` drives state transitions in one of
+two ways:
+
+1. **LLM-guided**: the agent asks the LLM to pick the next state from the
+   available transitions declared in `state_graph.yaml`.
+2. **Forced override**: a state sets `structured_data["next_state"]` in its
+   `StateOutput`, and the agent follows it directly without calling the LLM.
+
+The forced override mechanism exists because the executor graph
+(`executor → tool → approval → executor_done`) is a fixed sequence. The next
+step after executing a tool is always `executor`; the next step after a
+declined approval is always `executor_done`. These are not decisions — they
+are predetermined. Running the LLM to "decide" would add latency, API cost,
+and non-determinism to what should be an invariant sequence.
+
+## Decision
+
+States that know their successor declare it explicitly via
+`structured_data["next_state"]`. The agent checks for this value before
+falling back to LLM-guided choice.
+
+The override is only honoured if the forced state is a declared transition for
+the current state in `state_graph.yaml`. If it is not, the agent falls back to
+normal choice — it never blindly jumps to an undeclared state.
+
+## States that use this mechanism
+
+| State | Forces next to | Why |
+|-------|---------------|-----|
+| `state_executor` | `executor_done`, `use_tool`, `ask_human` | Fixed plan step sequencing |
+| `state_tool` | `executor` | After tool call, always return to executor |
+| `state_approval` | `executor`, `executor_done` | Approved → continue; declined → end |
+| `state_plan` | `ask_user` | Plan card always returns to user |
+| `state_ai` | `ask_user`, `workshop_plan` | Route is determined by structured reasoning output |
+
+## Consequences
+
+- Adding a new executor-style state requires setting `next_state` in its
+  `StateOutput` and declaring the transition in `state_graph.yaml`.
+- Chat-path states (`state_ai`, `state_user`) can use the override too when
+  their next step is unambiguous, reducing unnecessary LLM calls.
+- The fallback invariant (`forced in transition_names`) means a misconfigured
+  `next_state` silently degrades to LLM choice rather than crashing.


### PR DESCRIPTION
## What changed
Added expanded inline comment at both forced-transition sites in `agent.py` and a new ADR at `docs/adr/001-forced-state-transition.md`.

## Why
The mechanism was undocumented. Team members couldn't determine which states depend on it or whether it was safe to modify. Closes MIT-228.

## Type
- [x] `docs`

## How to test
Read `agent_module/agent.py` lines 268-290 and `docs/adr/001-forced-state-transition.md`. No runtime behavior changed.

```bash
python -m pytest tests/ -v -m "not integration"
```

## Checklist
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pytest tests/ -v -m "not integration"` passes
- [x] No unrelated changes in this PR