### PR TITLE
Slack integration

### DIFF
--- a/base_module/users.py
+++ b/base_module/users.py
@@ -36,6 +36,11 @@ class LoginResponse(BaseModel):
 class MeResponse(BaseModel):
     user_id: str
     username: str
+    slack_user_id: str | None = None
+
+
+class SlackConnectRequest(BaseModel):
+    slack_user_id: str = Field(..., pattern=r"^U[A-Z0-9]{8,}$")
 
 
 def _connect():
@@ -86,7 +91,43 @@ async def demo_login(req: DemoLoginRequest) -> LoginResponse:
     return LoginResponse(token=token, user_id=user_id, username=uname)
 
 
+def _get_slack_user_id(user_id: str) -> str | None:
+    conn = _connect()
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SELECT slack_user_id FROM users WHERE id = %s", (user_id,))
+            row = cur.fetchone()
+            return row["slack_user_id"] if row else None
+    finally:
+        conn.close()
+
+
 @router.get("/me", response_model=MeResponse)
 async def me(current: dict[str, Any] = CurrentUser) -> MeResponse:
     """GET /auth/me. Returns the authenticated user from the Bearer token."""
-    return MeResponse(user_id=current["user_id"], username=current["username"])
+    slack_user_id = _get_slack_user_id(current["user_id"])
+    return MeResponse(user_id=current["user_id"], username=current["username"], slack_user_id=slack_user_id)
+
+
+@router.post("/slack-connect", status_code=204)
+async def slack_connect(
+    req: SlackConnectRequest,
+    current: dict[str, Any] = CurrentUser,
+) -> None:
+    """
+    POST /auth/slack-connect
+    Body: {"slack_user_id": "U012AB3CD"}
+    Links the calling user's ARKOS account to their Slack member ID for task notifications.
+    """
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE users SET slack_user_id = %s WHERE id = %s",
+                (req.slack_user_id, current["user_id"]),
+            )
+        conn.commit()
+    except psycopg2.Error as e:
+        raise HTTPException(500, f"db error: {e}") from e
+    finally:
+        conn.close()

--- a/config_module/config.yaml
+++ b/config_module/config.yaml
@@ -1,6 +1,6 @@
 app:
   host: "0.0.0.0"
-  port: "1114"
+  port: "1121"
   reload: true
   system_prompt: |
     THIS IS A NEW CONVERSATION (past converation info is above)
@@ -66,6 +66,13 @@ mcp_servers:
     mcp_url: "https://googlecalendar.run.tools"
     requires_auth: true
     name: "Google Calendar"
+
+  slack:
+    mcp_url: "https://slack--node2flow.run.tools"
+    requires_auth: false
+    name: "Slack"
+    headers:
+      SLACK_BOT_TOKEN: "${SLACK_BOT_TOKEN}"
 
 
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -442,6 +442,7 @@ function openSettings() {
   document.getElementById('settingsBackend').textContent = CONFIG.backend;
   settingsModal.classList.add('open');
   refreshConnections();
+  loadSlackUserId();
 }
 function closeSettings() {
   settingsModal.classList.remove('open');
@@ -580,6 +581,56 @@ connList.addEventListener('click', (e) => {
   const discBtn = e.target.closest('[data-disconnect]');
   if (discBtn) {
     disconnectService(discBtn.getAttribute('data-disconnect'));
+  }
+});
+
+// ---------- slack member id ----------
+async function loadSlackUserId() {
+  try {
+    const r = await fetch(CONFIG.backend + '/auth/me', { headers: authHeaders() });
+    if (!r.ok) return;
+    const d = await r.json();
+    const input = document.getElementById('slackUserIdInput');
+    const statusEl = document.getElementById('slackStatus');
+    if (d.slack_user_id) {
+      input.value = d.slack_user_id;
+      statusEl.textContent = 'connected';
+      statusEl.className = 'status ok';
+    } else {
+      statusEl.textContent = 'not set';
+      statusEl.className = 'status';
+    }
+  } catch (_) {}
+}
+
+document.getElementById('slackSaveBtn').addEventListener('click', async () => {
+  const input = document.getElementById('slackUserIdInput');
+  const statusEl = document.getElementById('slackStatus');
+  const btn = document.getElementById('slackSaveBtn');
+  const val = input.value.trim();
+  if (!val) return;
+  btn.disabled = true;
+  btn.textContent = 'saving...';
+  try {
+    const r = await fetch(CONFIG.backend + '/auth/slack-connect', {
+      method: 'POST',
+      headers: authHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ slack_user_id: val }),
+    });
+    if (r.ok) {
+      statusEl.textContent = 'connected';
+      statusEl.className = 'status ok';
+    } else {
+      const e = await r.json().catch(() => ({}));
+      statusEl.textContent = e.detail || 'error';
+      statusEl.className = 'status err';
+    }
+  } catch (_) {
+    statusEl.textContent = 'error';
+    statusEl.className = 'status err';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'save';
   }
 });
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -132,6 +132,25 @@
     </section>
 
     <section>
+      <h3>notifications</h3>
+      <div style="font-size:11px;color:var(--fg-mute);margin-bottom:10px;">
+        get notified in Slack when tasks start or complete.<br>
+        find your member id: Slack profile &rarr; &middot;&middot;&middot; &rarr; copy member id
+      </div>
+      <div class="conn-row">
+        <div>
+          <span class="name">Slack DMs</span>
+          <span class="status" id="slackStatus">not set</span>
+        </div>
+        <div style="display:flex;gap:6px;align-items:center;">
+          <input id="slackUserIdInput" autocomplete="off" spellcheck="false" placeholder="U012AB3CD"
+            style="font-family:var(--mono);font-size:11px;background:transparent;border:1px solid var(--bg-line);color:var(--fg);padding:6px 10px;width:114px;" />
+          <button id="slackSaveBtn">save</button>
+        </div>
+      </div>
+    </section>
+
+    <section>
       <h3>account</h3>
       <div style="font-size:11px;color:var(--fg-mute);">
         signed in as <b id="settingsUser">—</b><br>

--- a/state_module/agent_executor/state_approval.py
+++ b/state_module/agent_executor/state_approval.py
@@ -26,6 +26,7 @@ from model_module.ArkModelNew import UserMessage
 from state_module.core.base_state import StateOutput
 from state_module.core.state import State
 from state_module.core.state_registry import register_state
+from tool_module.slack_notify import send_dm
 
 
 @register_state
@@ -89,6 +90,10 @@ class StateApproval(State):
             prompt=prompt,
             context={"plan_step_idx": getattr(agent, "step_idx", 0)},
         )
+
+        public_url = config.get("app.public_url") or "http://localhost:1113"
+        approval_url = f"{public_url}/app/"
+        await send_dm(user_id, f"Arkos needs your input:\n\n{prompt}\n\nApprove at: {approval_url}")
 
         set_task_status(task_id, "awaiting_approval")
         log_event(

--- a/tests/test_slack_notify.py
+++ b/tests/test_slack_notify.py
@@ -1,0 +1,141 @@
+"""Tests for tool_module/slack_notify.py — DB lookup and send_dm branches.
+
+Mocks psycopg2 and aiohttp — no live DB or Slack API calls.
+Does not test message content quality, only control flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from tool_module.slack_notify import _get_slack_user_id, send_dm
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(json_data: dict) -> MagicMock:
+    """Async context manager mock for a single aiohttp response."""
+    r = MagicMock()
+    r.json = AsyncMock(return_value=json_data)
+    r.__aenter__ = AsyncMock(return_value=r)
+    r.__aexit__ = AsyncMock(return_value=False)
+    return r
+
+
+def _make_session(*responses: MagicMock) -> MagicMock:
+    """Async context manager mock for aiohttp.ClientSession.
+
+    Each positional arg is the response returned by successive session.post() calls.
+    """
+    it = iter(responses)
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.post = MagicMock(side_effect=lambda *a, **kw: next(it))
+    return session
+
+
+# ---------------------------------------------------------------------------
+# _get_slack_user_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetSlackUserId:
+    def _mock_conn(self, row: dict | None) -> MagicMock:
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.__enter__ = MagicMock(return_value=cur)
+        cur.__exit__ = MagicMock(return_value=False)
+        cur.fetchone.return_value = row
+        conn.cursor.return_value = cur
+        return conn
+
+    def test_returns_slack_id_when_row_exists(self):
+        conn = self._mock_conn({"slack_user_id": "U012AB3CD"})
+        with patch("tool_module.slack_notify.psycopg2.connect", return_value=conn):
+            result = _get_slack_user_id("user-1")
+        assert result == "U012AB3CD"
+
+    def test_returns_none_when_no_row(self):
+        conn = self._mock_conn(None)
+        with patch("tool_module.slack_notify.psycopg2.connect", return_value=conn):
+            result = _get_slack_user_id("user-1")
+        assert result is None
+
+    def test_returns_none_when_slack_id_is_null(self):
+        conn = self._mock_conn({"slack_user_id": None})
+        with patch("tool_module.slack_notify.psycopg2.connect", return_value=conn):
+            result = _get_slack_user_id("user-1")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# send_dm
+# ---------------------------------------------------------------------------
+
+
+class TestSendDm:
+    def test_noop_when_user_has_no_slack_id(self):
+        with patch("tool_module.slack_notify._get_slack_user_id", return_value=None):
+            with patch("tool_module.slack_notify.aiohttp.ClientSession") as mock_cls:
+                asyncio.run(send_dm("user-1", "hello"))
+                mock_cls.assert_not_called()
+
+    def test_noop_when_bot_token_not_configured(self):
+        with patch("tool_module.slack_notify._get_slack_user_id", return_value="U012AB3CD"):
+            with patch("tool_module.slack_notify.config") as mock_cfg:
+                mock_cfg.get.return_value = None
+                with patch("tool_module.slack_notify.aiohttp.ClientSession") as mock_cls:
+                    asyncio.run(send_dm("user-1", "hello"))
+                    mock_cls.assert_not_called()
+
+    def test_sends_dm_calls_both_slack_endpoints(self):
+        open_resp = _make_response({"ok": True, "channel": {"id": "DM123"}})
+        post_resp = _make_response({"ok": True})
+        session = _make_session(open_resp, post_resp)
+
+        with patch("tool_module.slack_notify._get_slack_user_id", return_value="U012AB3CD"):
+            with patch("tool_module.slack_notify.config") as mock_cfg:
+                mock_cfg.get.return_value = "xoxb-test-token"
+                with patch("tool_module.slack_notify.aiohttp.ClientSession", return_value=session):
+                    asyncio.run(send_dm("user-1", "task done"))
+
+        assert session.post.call_count == 2
+        urls = [c.args[0] for c in session.post.call_args_list]
+        assert any("conversations.open" in u for u in urls)
+        assert any("chat.postMessage" in u for u in urls)
+
+    def test_logs_warning_and_returns_when_conversations_open_fails(self, caplog):
+        open_resp = _make_response({"ok": False, "error": "not_in_channel"})
+        session = _make_session(open_resp)
+
+        with patch("tool_module.slack_notify._get_slack_user_id", return_value="U012AB3CD"):
+            with patch("tool_module.slack_notify.config") as mock_cfg:
+                mock_cfg.get.return_value = "xoxb-test-token"
+                with patch("tool_module.slack_notify.aiohttp.ClientSession", return_value=session):
+                    with caplog.at_level(logging.WARNING, logger="tool_module.slack_notify"):
+                        asyncio.run(send_dm("user-1", "hello"))
+
+        assert session.post.call_count == 1  # chat.postMessage was never called
+        assert "conversations.open failed" in caplog.text
+
+    def test_logs_warning_when_post_message_fails(self, caplog):
+        open_resp = _make_response({"ok": True, "channel": {"id": "DM123"}})
+        post_resp = _make_response({"ok": False, "error": "channel_not_found"})
+        session = _make_session(open_resp, post_resp)
+
+        with patch("tool_module.slack_notify._get_slack_user_id", return_value="U012AB3CD"):
+            with patch("tool_module.slack_notify.config") as mock_cfg:
+                mock_cfg.get.return_value = "xoxb-test-token"
+                with patch("tool_module.slack_notify.aiohttp.ClientSession", return_value=session):
+                    with caplog.at_level(logging.WARNING, logger="tool_module.slack_notify"):
+                        asyncio.run(send_dm("user-1", "hello"))
+
+        assert "chat.postMessage failed" in caplog.text

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -7,7 +7,7 @@ and the DB-error fallback.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import psycopg2
 import pytest
@@ -20,6 +20,7 @@ from base_module.users import (
     DemoLoginRequest,
     LoginResponse,
     MeResponse,
+    SlackConnectRequest,
     router,
 )
 
@@ -87,6 +88,11 @@ class TestMeResponse:
         resp = MeResponse(user_id="u-1", username="alice")
         assert resp.user_id == "u-1"
         assert resp.username == "alice"
+        assert resp.slack_user_id is None
+
+    def test_slack_user_id_stored(self):
+        resp = MeResponse(user_id="u-1", username="alice", slack_user_id="U012AB3CD")
+        assert resp.slack_user_id == "U012AB3CD"
 
 
 # ---------------------------------------------------------------------------
@@ -139,15 +145,23 @@ class TestDemoLoginRoute:
 
 class TestMeRoute:
     def test_returns_user_from_bearer(self, client):
-        # Issue a real token rather than mocking the dependency, so we cover
-        # the JWT roundtrip in a single integration-ish unit test.
         from base_module.jwt_utils import issue_token
 
         token = issue_token("u-42", "alice")
-        resp = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+        with patch("base_module.users._get_slack_user_id", return_value=None):
+            resp = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
         assert resp.status_code == 200
         body = resp.json()
-        assert body == {"user_id": "u-42", "username": "alice"}
+        assert body == {"user_id": "u-42", "username": "alice", "slack_user_id": None}
+
+    def test_returns_slack_user_id_when_linked(self, client):
+        from base_module.jwt_utils import issue_token
+
+        token = issue_token("u-42", "alice")
+        with patch("base_module.users._get_slack_user_id", return_value="U012AB3CD"):
+            resp = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        assert resp.json()["slack_user_id"] == "U012AB3CD"
 
     def test_rejects_missing_token(self, client):
         resp = client.get("/auth/me")
@@ -155,4 +169,66 @@ class TestMeRoute:
 
     def test_rejects_invalid_token(self, client):
         resp = client.get("/auth/me", headers={"Authorization": "Bearer garbage"})
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# SlackConnectRequest schema
+# ---------------------------------------------------------------------------
+
+
+class TestSlackConnectRequest:
+    @pytest.mark.parametrize("uid", ["U012AB3CD", "UABCDEFGHI", "U1234567890"])
+    def test_accepts_valid_slack_ids(self, uid):
+        req = SlackConnectRequest(slack_user_id=uid)
+        assert req.slack_user_id == uid
+
+    @pytest.mark.parametrize("uid", ["u012ab3cd", "W012AB3CD", "U0123", "notanid", ""])
+    def test_rejects_invalid_slack_ids(self, uid):
+        with pytest.raises(ValueError):
+            SlackConnectRequest(slack_user_id=uid)
+
+
+# ---------------------------------------------------------------------------
+# /auth/slack-connect route
+# ---------------------------------------------------------------------------
+
+
+class TestSlackConnectRoute:
+    @pytest.fixture
+    def authed_client(self):
+        from base_module.jwt_utils import issue_token
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        client.headers = {"Authorization": f"Bearer {issue_token('u-1', 'alice')}"}
+        return client
+
+    def test_returns_204_on_success(self, authed_client):
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.__enter__ = MagicMock(return_value=cur)
+        cur.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cur
+        with patch("base_module.users._connect", return_value=conn):
+            resp = authed_client.post("/auth/slack-connect", json={"slack_user_id": "U012AB3CD"})
+        assert resp.status_code == 204
+        cur.execute.assert_called_once()
+        conn.commit.assert_called_once()
+
+    def test_rejects_bad_slack_id_format(self, authed_client):
+        resp = authed_client.post("/auth/slack-connect", json={"slack_user_id": "notanid"})
+        assert resp.status_code == 422
+
+    def test_db_error_returns_500(self, authed_client):
+        conn = MagicMock()
+        conn.cursor.side_effect = psycopg2.OperationalError("connection refused")
+        with patch("base_module.users._connect", return_value=conn):
+            resp = authed_client.post("/auth/slack-connect", json={"slack_user_id": "U012AB3CD"})
+        assert resp.status_code == 500
+        assert "db error" in resp.json()["detail"]
+
+    def test_requires_auth(self, client):
+        resp = client.post("/auth/slack-connect", json={"slack_user_id": "U012AB3CD"})
         assert resp.status_code == 401

--- a/tool_module/slack_notify.py
+++ b/tool_module/slack_notify.py
@@ -1,0 +1,67 @@
+"""
+Sends proactive Slack DMs from background task processes.
+
+Uses the bot token directly — does NOT go through Smithery/MCP, which
+requires an active agent session that background tasks don't have.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiohttp
+import psycopg2
+import psycopg2.extras
+
+from config_module.loader import config
+
+logger = logging.getLogger(__name__)
+
+
+def _get_slack_user_id(user_id: str) -> str | None:
+    conn = psycopg2.connect(config.get("database.url"))
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SELECT slack_user_id FROM users WHERE id = %s", (user_id,))
+            row = cur.fetchone()
+            return row["slack_user_id"] if row else None
+    finally:
+        conn.close()
+
+
+async def send_dm(user_id: str, text: str) -> None:
+    """
+    Send a Slack DM to the user associated with the given ARKOS user_id.
+
+    Args:
+        user_id: ARKOS UUID — looked up against the users table for slack_user_id.
+        text: Message body sent to the user's Slack DM channel.
+
+    Silently no-ops if the user hasn't linked their Slack account.
+    """
+    slack_uid = _get_slack_user_id(user_id)
+    if not slack_uid:
+        return
+    token = config.get("mcp_servers.slack.headers.SLACK_BOT_TOKEN")
+    if not token:
+        logger.warning("send_dm: SLACK_BOT_TOKEN not configured, skipping")
+        return
+    headers = {"Authorization": f"Bearer {token}"}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            "https://slack.com/api/conversations.open",
+            headers=headers,
+            json={"users": slack_uid},
+        ) as r:
+            dm = await r.json()
+        if not dm.get("ok"):
+            logger.warning("send_dm: conversations.open failed: %s", dm.get("error"))
+            return
+        async with session.post(
+            "https://slack.com/api/chat.postMessage",
+            headers=headers,
+            json={"channel": dm["channel"]["id"], "text": text},
+        ) as r:
+            body = await r.json()
+        if not body.get("ok"):
+            logger.warning("send_dm: chat.postMessage failed: %s", body.get("error"))


### PR DESCRIPTION
## What changed
Adds Slack DM notifications: users can link their Slack account in Settings, and the executor sends them a DM when a task needs approval.

## Why
Background tasks have no way to pull users back to the app when they're waiting for input so Slack DMs.

## Type
- [x] `feat` — new feature

## How to test
1. Set `SLACK_BOT_TOKEN` in env (the bot must be in the workspace).
2. Start the app and open Settings -> Notifications.
3. Enter your Slack member ID (Slack profile -> ··· -> Copy member ID) and click **save**.
4. Confirm `GET /auth/me` returns `slack_user_id` and `POST /auth/slack-connect` returns 204.
5. Trigger a task that reaches the approval state - you should receive a Slack DM with the prompt and an approve link.

```bash
# verify the endpoint directly
curl -X POST http://localhost:1121/auth/slack-connect \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"slack_user_id": "U012AB3CD"}'
# expect 204
