### PR TITLE
[agent] fix: state machine correctness bugs

### DIFF
--- a/agent_module/agent.py
+++ b/agent_module/agent.py
@@ -389,9 +389,15 @@ class Agent:
 
             if update:
                 assert isinstance(update, StateOutput), "State output was not a StateOutput instance"
-                self.last_state_output = update
                 if update.content:
+                    self.last_state_output = update
                     await self.add_context([AIMessage(content=update.content)])
+                elif self.last_state_output is None:
+                    # A terminal hand-back state (e.g. ask_user) returns empty
+                    # content; don't let it clobber a real reply produced
+                    # earlier this turn. Keep an empty output only as a last
+                    # resort when nothing else was produced.
+                    self.last_state_output = update
 
             if update and update.completion_signal == "error" and not self.current_state.is_terminal:
                 # Route errors to the reply state when it exists (buddy graph).

--- a/agent_module/agent.py
+++ b/agent_module/agent.py
@@ -497,7 +497,11 @@ class Agent:
                         yield {"type": "content", "text": char}
 
             if update and update.completion_signal == "error" and not self.current_state.is_terminal:
-                self.current_state = self.flow.get_state("agent_reply")
+                # Mirror step(): only hop to the reply state when this graph has
+                # one. The executor graph has no "agent_reply"; guarding avoids a
+                # KeyError and lets it fall through to model_error.
+                if "agent_reply" in self.flow.states:
+                    self.current_state = self.flow.get_state("agent_reply")
                 self.terminal_reason = TerminalReason.model_error
                 break
 

--- a/state_module/agent_executor/graph.yaml
+++ b/state_module/agent_executor/graph.yaml
@@ -16,7 +16,7 @@ states:
     description: "executes the tool chosen for the current plan step"
     type: executor_tool
     transition:
-      next: [executor]
+      next: [executor, ask_human]
 
   ask_human:
     description: "pauses the subagent and asks the human a binary or text question"

--- a/state_module/agent_executor/routers.py
+++ b/state_module/agent_executor/routers.py
@@ -36,9 +36,14 @@ def use_tool_router(output: StateOutput) -> str:
     """
     Routes after executor/state_tool runs.
 
-    Always loops back to executor so it can pick the next plan step.
-    The route signal is not checked; there is only one valid destination.
+    Signals
+    -------
+    ask    -> ask_human  (the tool could not complete; pause for a human)
+    <else> -> executor   (tool ran; loop back so executor picks the next action)
     """
+    route = (output.structured_data or {}).get("route", "")
+    if route == "ask":
+        return "ask_human"
     return "executor"
 
 

--- a/state_module/agent_executor/state_tool.py
+++ b/state_module/agent_executor/state_tool.py
@@ -76,6 +76,25 @@ class StateExecutorTool(State):
                     "route": "ask",
                 },
             )
+        except Exception as e:
+            # A tool can fail for non-auth reasons (network, bad args, server
+            # error). Don't let one failed step fail the whole task — ask the
+            # human how to proceed and let the executor resume from there.
+            if task_id and log_event:
+                log_event(task_id, "tool_error", str(e)[:500], payload={"tool_name": tool_name})
+            agent.pending_ask = {
+                "kind": "text",
+                "prompt": (
+                    f"The tool `{tool_name}` failed while running this step:\n"
+                    f"{str(e)[:300]}\nHow should I proceed?"
+                ),
+            }
+            return StateOutput(
+                content=f"tool `{tool_name}` failed: {str(e)[:200]}",
+                completion_signal="error",
+                error_detail=str(e),
+                structured_data={"route": "ask"},
+            )
 
         if task_id and log_event:
             log_event(task_id, "tool_result", str(tool_result)[:2000], payload={"tool_name": tool_name})

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -347,3 +347,27 @@ class TestStepOutput:
 
         result = await agent.step([UserMessage(content="hi")])
         assert result.content == "here is your answer"
+
+    @pytest.mark.asyncio
+    async def test_step_stream_error_tolerates_graph_without_agent_reply(self, agent):
+        """An error in a graph lacking 'agent_reply' must not KeyError."""
+        agent.memory.add_memory = AsyncMock()
+        agent.memory.retrieve_short_memory = AsyncMock(return_value=[])
+        agent.memory.retrieve_long_memory = AsyncMock(return_value=None)
+
+        err = StateOutput(content="boom", completion_signal="error", error_detail="kaboom")
+        state = MagicMock(is_terminal=False)
+        state.name = "executor"
+        state.run = AsyncMock(return_value=err)
+
+        agent.current_state = state
+        # Executor-like graph: no 'agent_reply'. The unguarded hop calls
+        # get_state("agent_reply") (KeyError below); the guarded one skips it.
+        agent.flow.states = {"executor": state}
+        agent.flow.get_state.side_effect = KeyError("agent_reply")
+        agent.flow.get_initial_state.return_value = state
+
+        events = [e async for e in agent.step_stream([UserMessage(content="hi")])]
+        text = "".join(e.get("text", "") for e in events if e.get("type") == "content")
+        assert "boom" in text
+        assert agent.terminal_reason == TerminalReason.model_error

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -316,3 +316,34 @@ class TestContextBudgeting:
 class TestMaxIter:
     def test_max_iter_constant(self):
         assert MAX_ITER == 10
+
+
+class TestStepOutput:
+    @pytest.mark.asyncio
+    async def test_step_keeps_reply_when_turn_ends_on_empty_state(self, agent):
+        """A reply followed by a terminal empty state must still be returned."""
+        agent.memory.add_memory = AsyncMock()
+        agent.memory.retrieve_short_memory = AsyncMock(return_value=[])
+        agent.memory.retrieve_long_memory = AsyncMock(return_value=None)
+
+        reply = StateOutput(content="here is your answer", completion_signal="complete")
+        empty = StateOutput(content="", completion_signal="needs_input")
+
+        state_reply = MagicMock(is_terminal=False)
+        state_reply.name = "agent_reply"
+        state_reply.check_transition_ready.return_value = True
+        state_reply.run = AsyncMock(return_value=reply)
+
+        state_wait = MagicMock(is_terminal=True)
+        state_wait.name = "ask_user"
+        state_wait.check_transition_ready.return_value = True
+        state_wait.run = AsyncMock(return_value=empty)
+
+        agent.current_state = state_reply
+        agent.flow.get_router.return_value = None
+        agent.flow.get_transitions.return_value = {"tt": ["ask_user"], "td": [("ask_user", "wait")]}
+        agent.flow.get_state.return_value = state_wait
+        agent.flow.get_initial_state.return_value = state_reply
+
+        result = await agent.step([UserMessage(content="hi")])
+        assert result.content == "here is your answer"

--- a/tests/test_state_module.py
+++ b/tests/test_state_module.py
@@ -12,6 +12,7 @@ from state_module.agent_buddy.state_ai import ReasonedOutput, StateAI
 from state_module.agent_buddy.state_tool import StateTool
 from state_module.agent_buddy.state_user import StateUser
 from state_module.agent_executor.routers import use_tool_router
+from state_module.agent_executor.state_tool import StateExecutorTool
 from state_module.core.base_state import StateOutput
 from state_module.core.state import State
 from state_module.core.state_registry import STATE_REGISTRY, register_state
@@ -364,6 +365,31 @@ class TestStateRegistry:
             @register_state
             class BadState:
                 pass
+
+
+# --- executor StateExecutorTool ---
+
+
+class TestStateExecutorTool:
+    @pytest.mark.asyncio
+    async def test_tool_error_asks_human(self):
+        """A non-auth tool failure routes to ask_human instead of killing the task."""
+        st = StateExecutorTool("use_tool", {})
+        mock_agent = MagicMock()
+        mock_agent.task_id = None
+        mock_agent.current_user_id = "u1"
+        mock_agent.step_idx = 0
+        mock_agent.pending_tool = {"tool_name": "search", "tool_args": {}}
+        mock_agent.tool_manager.call_tool = AsyncMock(side_effect=RuntimeError("network down"))
+
+        result = await st.run([], mock_agent)
+
+        assert result.completion_signal == "error"
+        assert result.structured_data["route"] == "ask"
+        assert mock_agent.pending_ask["kind"] == "text"
+        assert "search" in mock_agent.pending_ask["prompt"]
+        # The failed step is not advanced past; the human decides next.
+        assert mock_agent.step_idx == 0
 
 
 # --- executor use_tool_router ---

--- a/tests/test_state_module.py
+++ b/tests/test_state_module.py
@@ -11,6 +11,7 @@ from model_module.errors import OutputValidationError
 from state_module.agent_buddy.state_ai import ReasonedOutput, StateAI
 from state_module.agent_buddy.state_tool import StateTool
 from state_module.agent_buddy.state_user import StateUser
+from state_module.agent_executor.routers import use_tool_router
 from state_module.core.base_state import StateOutput
 from state_module.core.state import State
 from state_module.core.state_registry import STATE_REGISTRY, register_state
@@ -363,6 +364,27 @@ class TestStateRegistry:
             @register_state
             class BadState:
                 pass
+
+
+# --- executor use_tool_router ---
+
+
+class TestUseToolRouter:
+    def test_ask_signal_routes_to_ask_human(self):
+        out = StateOutput(
+            content="boom",
+            completion_signal="error",
+            structured_data={"route": "ask"},
+        )
+        assert use_tool_router(out) == "ask_human"
+
+    def test_other_signals_route_to_executor(self):
+        out = StateOutput(
+            content="ok",
+            completion_signal="complete",
+            structured_data={"route": "continue"},
+        )
+        assert use_tool_router(out) == "executor"
 
 
 # --- StateHandler ---


### PR DESCRIPTION
## What
Fix four state-machine correctness bugs in the buddy loop and executor subagent.

## Why
Non-streaming replies came back empty, a streamed error crashed any graph without `agent_reply`, and executor tool failures (auth or runtime) silently failed the whole task.

## How
- `agent.step()`: record the last *non-empty* output so a terminal empty state (`ask_user`) can't clobber the reply
- `agent.step_stream()`: guard the `agent_reply` error-hop, mirroring `step()`
- `use_tool_router`: honor the `ask` route signal → `ask_human` (edge declared in `graph.yaml`)
- executor tool state: catch non-auth tool exceptions and route to `ask_human` instead of failing the task

## Test
`pytest tests/test_agent.py tests/test_state_module.py` → 71 passed (5 new). `ruff` clean on all touched files.

## Checklist
- [x] Tests added (`test_agent.py`, `test_state_module.py`)
- [x] No new `ruff` warnings in touched files (repo has pre-existing debt unrelated to this PR)
- [x] No credentials or `print()` added
